### PR TITLE
Warn on empty configurations.

### DIFF
--- a/element-connector/src/main/java/org/eclipse/californium/elements/Definitions.java
+++ b/element-connector/src/main/java/org/eclipse/californium/elements/Definitions.java
@@ -130,6 +130,27 @@ public class Definitions<T extends Definition<?>> implements Iterable<T> {
 		return definitions.get(key);
 	}
 
+	/**
+	 * Check, if definitions are available.
+	 * 
+	 * @return {@code true}, if no definitions are available, {@code false}, if
+	 *         definitions are available.
+	 * @since 3.8
+	 */
+	public boolean isEmpty() {
+		return definitions.isEmpty();
+	}
+
+	/**
+	 * Get number of available definitions.
+	 * 
+	 * @return number of available definitions.
+	 * @since 3.8
+	 */
+	public int size() {
+		return definitions.size();
+	}
+
 	@Override
 	public Iterator<T> iterator() {
 		return definitions.values().iterator();

--- a/element-connector/src/main/java/org/eclipse/californium/elements/config/Configuration.java
+++ b/element-connector/src/main/java/org/eclipse/californium/elements/config/Configuration.java
@@ -498,6 +498,9 @@ public final class Configuration {
 		this.definitions = DEFAULT_DEFINITIONS;
 		this.modules = DEFAULT_MODULES;
 		applyModules();
+		if (modules.isEmpty() && definitions.isEmpty() && values.isEmpty()) {
+			LOGGER.warn("Configuration contains no modules, no definitions, and no values!", new Throwable("stacktrace"));
+		}
 	}
 
 	/**
@@ -513,6 +516,9 @@ public final class Configuration {
 				: new ConcurrentHashMap<String, Configuration.DefinitionsProvider>(config.modules);
 		this.transientValues.addAll(config.transientValues);
 		this.values.putAll(config.values);
+		if (modules.isEmpty() && definitions.isEmpty() && values.isEmpty()) {
+			LOGGER.warn("Configuration contains no modules, no definitions, and no values!", new Throwable("stacktrace"));
+		}
 	}
 
 	/**
@@ -530,6 +536,9 @@ public final class Configuration {
 			}
 		}
 		applyModules();
+		if (modules.isEmpty() && definitions.isEmpty() && values.isEmpty()) {
+			LOGGER.warn("Configuration contains no modules, no definitions, and no values!", new Throwable("stacktrace"));
+		}
 	}
 
 	/**


### PR DESCRIPTION
Usually occurs, if Californium was already started in other components, which didn't register the configuration modules properly.

Signed-off-by: Achim Kraus <achim.kraus@cloudcoap.net>