### PR TITLE
Add configuration to disable reuse of tokens on blockwise transfer.

### DIFF
--- a/californium-core/src/main/java/org/eclipse/californium/core/config/CoapConfig.java
+++ b/californium-core/src/main/java/org/eclipse/californium/core/config/CoapConfig.java
@@ -611,12 +611,27 @@ public final class CoapConfig {
 	 * adapt the block size when receiving a 4.13 Entity too large response
 	 * code.
 	 * <p>
-	 * See https://tools.ietf.org/html/rfc7959#section-2.9.3 for more details.
+	 * @see <a href="https://tools.ietf.org/html/rfc7959#section-2.9.3" target="_blank">RFC7959, 2.9.3. - 4.13 Request Entity Too Large</a>
 	 */
 	public static final BooleanDefinition BLOCKWISE_ENTITY_TOO_LARGE_AUTO_FAILOVER = new BooleanDefinition(
 			MODULE + "BLOCKWISE_ENTITY_TOO_LARGE_AUTO_FAILOVER",
 			"Enable automatic failover on \"entity too large\" response.",
 			DEFAULT_BLOCKWISE_ENTITY_TOO_LARGE_AUTO_FAILOVER);
+	/**
+	 * Property to indicate that blockwise follow-up requests are reusing the
+	 * same token for traceability.
+	 * <p>
+	 * <b>Note:</b> reusing tokens may introduce a vulnerability, if
+	 * requests/response are captured and sent later without protecting the
+	 * integrity of the payload by other means.
+	 * </p>
+	 * 
+	 * @see <a href="https://github.com/core-wg/attacks-on-coap" target="_blank">attacks-on-coap</a>
+	 * @since 3.8
+	 */
+	public static final BooleanDefinition BLOCKWISE_REUSE_TOKEN = new BooleanDefinition(
+			MODULE + "BLOCKWISE_REUSE_TOKEN",
+			"Reuse token for blockwise requests. Ease traceability but may introduce vulnerability.", false);
 
 	/**
 	 * Time interval for a coap-server to check the client's interest in further
@@ -794,6 +809,7 @@ public final class CoapConfig {
 			config.set(BLOCKWISE_STATUS_INTERVAL, DEFAULT_BLOCKWISE_STATUS_INTERVAL_IN_SECONDS, TimeUnit.SECONDS);
 			config.set(BLOCKWISE_STRICT_BLOCK2_OPTION, DEFAULT_BLOCKWISE_STRICT_BLOCK2_OPTION);
 			config.set(BLOCKWISE_ENTITY_TOO_LARGE_AUTO_FAILOVER, DEFAULT_BLOCKWISE_ENTITY_TOO_LARGE_AUTO_FAILOVER);
+			config.set(BLOCKWISE_REUSE_TOKEN, false);
 			// BERT enabled, when > 1
 			config.set(TCP_NUMBER_OF_BULK_BLOCKS, 4);
 

--- a/californium-core/src/main/java/org/eclipse/californium/core/network/stack/Block1BlockwiseStatus.java
+++ b/californium-core/src/main/java/org/eclipse/californium/core/network/stack/Block1BlockwiseStatus.java
@@ -33,6 +33,13 @@ public final class Block1BlockwiseStatus extends BlockwiseStatus {
 	private static final Logger LOGGER = LoggerFactory.getLogger(Block1BlockwiseStatus.class);
 
 	/**
+	 * Current pending block wise request.
+	 * 
+	 * @since 3.8
+	 */
+	private Request current;
+
+	/**
 	 * Create block1wise status.
 	 * 
 	 * @param keyUri key uri of the blockwise transfer
@@ -47,6 +54,7 @@ public final class Block1BlockwiseStatus extends BlockwiseStatus {
 	private Block1BlockwiseStatus(KeyUri keyUri, RemoveHandler removeHandler, Exchange exchange, Request request,
 			int maxSize, int maxTcpBertBulkBlocks) {
 		super(keyUri, removeHandler, exchange, request, maxSize, maxTcpBertBulkBlocks);
+		current = request;
 	}
 
 	/**
@@ -189,6 +197,7 @@ public final class Block1BlockwiseStatus extends BlockwiseStatus {
 		block.getOptions().setBlock1(blockSzx, m, num);
 
 		setComplete(!m);
+		current = block;
 		return block;
 	}
 
@@ -214,13 +223,15 @@ public final class Block1BlockwiseStatus extends BlockwiseStatus {
 	}
 
 	/**
-	 * Checks whether a response has the same token as the request that
-	 * initiated the block1 transfer that this is the tracker for.
+	 * Checks whether a response has the same token as the current request of
+	 * this tracker.
 	 * 
 	 * @param response The response to check.
 	 * @return {@code true} if the tokens match.
+	 * @since 3.8 use the current request instead of the initial request to
+	 *        support blockwise transfer with changing tokens.
 	 */
-	public boolean hasMatchingToken(final Response response) {
-		return response.getToken().equals(firstMessage.getToken());
+	public synchronized boolean hasMatchingToken(final Response response) {
+		return response.getToken().equals(current.getToken());
 	}
 }

--- a/californium-core/src/test/java/org/eclipse/californium/core/test/lockstep/BlockwiseClientSideTest.java
+++ b/californium-core/src/test/java/org/eclipse/californium/core/test/lockstep/BlockwiseClientSideTest.java
@@ -844,7 +844,7 @@ public class BlockwiseClientSideTest {
 		server.sendResponse(ACK, CONTINUE).loadBoth("B").block1(1, true, 128).go();
 
 		server.expectRequest(CON, PUT, path).storeBoth("B").block1(2, false, 128).payload(reqtPayload, 256, 300).go();
-		server.sendResponse(ACK, CHANGED).loadBoth("B").go();
+		server.sendResponse(ACK, CHANGED).loadBoth("B").block1(2, false, 128).go();
 
 		Response response = concurrentRequest.waitForResponse(ERROR_TIMEOUT_IN_MS);
 		assertThat(response, is(notNullValue()));

--- a/cf-oscore/src/main/java/org/eclipse/californium/oscore/ObjectSecurityContextLayer.java
+++ b/cf-oscore/src/main/java/org/eclipse/californium/oscore/ObjectSecurityContextLayer.java
@@ -233,9 +233,9 @@ public class ObjectSecurityContextLayer extends AbstractLayer {
 		// Handle incoming OSCORE responses that have been re-assembled by the
 		// block-wise layer (for outer block-wise). If a response was not
 		// processed by OSCORE in the ObjectSecurityLayer it will happen here.
-		boolean outerBlockwise = exchange.getCurrentResponse() != null
-				&& exchange.getCurrentResponse().getOptions().hasBlock2()
-				&& ctxDb.getContextByToken(exchange.getCurrentResponse().getToken()) != null;
+		Response rawResponse =  exchange.getCurrentResponse();
+		boolean outerBlockwise = rawResponse.getOptions().hasBlock2()
+				&& ctxDb.getContextByToken(rawResponse.getToken()) != null;
 		if (outerBlockwise) {
 
 			LOGGER.debug("Incoming OSCORE response uses outer block-wise");
@@ -270,8 +270,6 @@ public class ObjectSecurityContextLayer extends AbstractLayer {
 			if (exchange.getRequest().isObserveCancel()) {
 				ctxDb.removeToken(response.getToken());
 			}
-
-			super.receiveResponse(exchange, response);
 		}
 
 		super.receiveResponse(exchange, response);


### PR DESCRIPTION
Improve protection from delay attacks, if no other means, maybe on application level, are available.

Signed-off-by: Achim Kraus <achim.kraus@cloudcoap.net>