### PR TITLE
Omit usage of function OptionSet.hasOption(int) in oscore.

### DIFF
--- a/cf-oscore/src/main/java/org/eclipse/californium/oscore/ObjectSecurityContextLayer.java
+++ b/cf-oscore/src/main/java/org/eclipse/californium/oscore/ObjectSecurityContextLayer.java
@@ -23,7 +23,6 @@ import org.slf4j.LoggerFactory;
 import org.eclipse.californium.core.coap.EmptyMessage;
 import org.eclipse.californium.core.coap.Message;
 import org.eclipse.californium.core.coap.MessageObserverAdapter;
-import org.eclipse.californium.core.coap.OptionNumberRegistry;
 import org.eclipse.californium.core.coap.OptionSet;
 import org.eclipse.californium.core.coap.Request;
 import org.eclipse.californium.core.coap.Response;
@@ -277,11 +276,11 @@ public class ObjectSecurityContextLayer extends AbstractLayer {
 
 	private static boolean shouldProtectRequest(Request request) {
 		OptionSet options = request.getOptions();
-		return options.hasOption(OptionNumberRegistry.OSCORE);
+		return options.hasOscore();
 	}
 
 	private static boolean isProtected(Message message) {
 		OptionSet options = message.getOptions();
-		return options.hasOption(OptionNumberRegistry.OSCORE);
+		return options.hasOscore();
 	}
 }

--- a/cf-oscore/src/main/java/org/eclipse/californium/oscore/ObjectSecurityLayer.java
+++ b/cf-oscore/src/main/java/org/eclipse/californium/oscore/ObjectSecurityLayer.java
@@ -23,7 +23,6 @@ import org.slf4j.LoggerFactory;
 import org.eclipse.californium.core.coap.EmptyMessage;
 import org.eclipse.californium.core.coap.Message;
 import org.eclipse.californium.core.coap.MessageObserverAdapter;
-import org.eclipse.californium.core.coap.OptionNumberRegistry;
 import org.eclipse.californium.core.coap.OptionSet;
 import org.eclipse.californium.core.coap.Request;
 import org.eclipse.californium.core.coap.Response;
@@ -421,7 +420,7 @@ public class ObjectSecurityLayer extends AbstractLayer {
 
 	private static boolean shouldProtectRequest(Request request) {
 		OptionSet options = request.getOptions();
-		return options.hasOption(OptionNumberRegistry.OSCORE);
+		return options.hasOscore();
 
 	}
 

--- a/cf-oscore/src/main/java/org/eclipse/californium/oscore/OptionJuggle.java
+++ b/cf-oscore/src/main/java/org/eclipse/californium/oscore/OptionJuggle.java
@@ -20,6 +20,7 @@
 package org.eclipse.californium.oscore;
 
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 
 import org.eclipse.californium.core.coap.Option;
@@ -299,10 +300,10 @@ public class OptionJuggle {
 	 */
 	public static OptionSet merge(OptionSet eOptions, OptionSet uOptions) {
 
-		List<Option> u = uOptions.asSortedList();
+		List<Option> e = eOptions.asSortedList();
 
-		for (Option tmp : u) {
-			if (!eOptions.hasOption(tmp.getNumber())) {
+		for (Option tmp : uOptions.asSortedList()) {
+			if (Collections.binarySearch(e, tmp) < 0) {
 				eOptions.addOption(tmp);
 			}
 		}


### PR DESCRIPTION
The function requires much CPU load. Replaced it by OptionSet.hasOscore() and single call to OptionSet.asSortedList().

Signed-off-by: Achim Kraus <achim.kraus@cloudcoap.net>