### PR TITLE
Datagram drop callback

### DIFF
--- a/element-connector/src/main/java/org/eclipse/californium/elements/util/LimitedRunnable.java
+++ b/element-connector/src/main/java/org/eclipse/californium/elements/util/LimitedRunnable.java
@@ -94,7 +94,7 @@ public abstract class LimitedRunnable implements Runnable {
 	 * Handles {@code RejectedExecutionException}
 	 * @param ex the thrown exception
 	 */
-	public abstract void onError(RejectedExecutionException ex);
+	public void onError(RejectedExecutionException ex) {};
 
 	/**
 	 * Execute this job.

--- a/element-connector/src/main/java/org/eclipse/californium/elements/util/LimitedRunnable.java
+++ b/element-connector/src/main/java/org/eclipse/californium/elements/util/LimitedRunnable.java
@@ -91,6 +91,12 @@ public abstract class LimitedRunnable implements Runnable {
 	}
 
 	/**
+	 * Handles {@code RejectedExecutionException}
+	 * @param ex the thrown exception
+	 */
+	public abstract void onError(RejectedExecutionException ex);
+
+	/**
 	 * Execute this job.
 	 * 
 	 * @param executor executor to execute jobs.
@@ -101,6 +107,7 @@ public abstract class LimitedRunnable implements Runnable {
 			executor.execute(this);
 		} catch (RejectedExecutionException ex) {
 			onDequeueing();
+			onError(ex);
 			throw ex;
 		}
 	}

--- a/element-connector/src/main/java/org/eclipse/californium/elements/util/LimitedRunnable.java
+++ b/element-connector/src/main/java/org/eclipse/californium/elements/util/LimitedRunnable.java
@@ -93,6 +93,8 @@ public abstract class LimitedRunnable implements Runnable {
 	/**
 	 * Handles {@code RejectedExecutionException}
 	 * @param ex the thrown exception
+	 *
+	 * @since 3.8
 	 */
 	public void onError(RejectedExecutionException ex) {};
 

--- a/scandium-core/src/main/java/org/eclipse/californium/scandium/DTLSConnector.java
+++ b/scandium-core/src/main/java/org/eclipse/californium/scandium/DTLSConnector.java
@@ -3079,9 +3079,6 @@ public class DTLSConnector implements Connector, PersistentConnector, Persistent
 					onDequeueing();
 				}
 			}
-
-			@Override
-			public void onError(RejectedExecutionException ex) {}
 		})) {
 			message.onError(new IllegalStateException("Outbound message overflow!"));
 		}
@@ -3538,9 +3535,6 @@ public class DTLSConnector implements Connector, PersistentConnector, Persistent
 								onDequeueing();
 							}
 						}
-
-						@Override
-						public void onError(RejectedExecutionException ex) {}
 					});
 				} catch (RuntimeException e) {
 					LOGGER.warn("Unexpected error occurred while processing handshake result [{}]", connection, e);

--- a/scandium-core/src/main/java/org/eclipse/californium/scandium/DatagramFilterExtended.java
+++ b/scandium-core/src/main/java/org/eclipse/californium/scandium/DatagramFilterExtended.java
@@ -1,0 +1,41 @@
+/*******************************************************************************
+ * Copyright (c) 2022 Bosch.IO GmbH and others.
+ * 
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * and Eclipse Distribution License v1.0 which accompany this distribution.
+ * 
+ * The Eclipse Public License is available at
+ *    http://www.eclipse.org/legal/epl-v20.html
+ * and the Eclipse Distribution License is available at
+ *    http://www.eclipse.org/org/documents/edl-v10.html.
+ * 
+ * Contributors:
+ *    Bosch IO.GmbH - initial creation
+ ******************************************************************************/
+package org.eclipse.californium.scandium;
+
+import org.eclipse.californium.elements.util.PublicAPIExtension;
+import org.eclipse.californium.scandium.dtls.Record;
+
+import java.net.DatagramPacket;
+import java.net.InetSocketAddress;
+
+/**
+ * Extension of DatagramFilter
+ */
+@PublicAPIExtension(type = DatagramFilter.class)
+public interface DatagramFilterExtended {
+
+	/**
+	 * Called when a datagram packed is dropped. Allows to inject packet based action in form of callback
+	 * @param packet the dropped datagram packet
+	 */
+	void onDrop(DatagramPacket packet);
+	/**
+	 * Called when a record is dropped. Allows to inject record based action in form of callback
+	 * @param record the dropped record
+	 */
+	void onDrop(Record record);
+	void onDrop(InetSocketAddress sourceAddress);
+}

--- a/scandium-core/src/main/java/org/eclipse/californium/scandium/DatagramFilterExtended.java
+++ b/scandium-core/src/main/java/org/eclipse/californium/scandium/DatagramFilterExtended.java
@@ -37,5 +37,4 @@ public interface DatagramFilterExtended {
 	 * @param record the dropped record
 	 */
 	void onDrop(Record record);
-	void onDrop(InetSocketAddress sourceAddress);
 }

--- a/scandium-core/src/main/java/org/eclipse/californium/scandium/DatagramFilterExtended.java
+++ b/scandium-core/src/main/java/org/eclipse/californium/scandium/DatagramFilterExtended.java
@@ -1,17 +1,17 @@
 /*******************************************************************************
- * Copyright (c) 2022 Bosch.IO GmbH and others.
- * 
+ * Copyright (c) 2022 AVSystem and others.
+ *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v2.0
  * and Eclipse Distribution License v1.0 which accompany this distribution.
- * 
+ *
  * The Eclipse Public License is available at
  *    http://www.eclipse.org/legal/epl-v20.html
  * and the Eclipse Distribution License is available at
  *    http://www.eclipse.org/org/documents/edl-v10.html.
- * 
+ *
  * Contributors:
- *    Bosch IO.GmbH - initial creation
+ *    Bartłomiej Wiśniewski (AVSystem) - initial creation
  ******************************************************************************/
 package org.eclipse.californium.scandium;
 
@@ -19,7 +19,6 @@ import org.eclipse.californium.elements.util.PublicAPIExtension;
 import org.eclipse.californium.scandium.dtls.Record;
 
 import java.net.DatagramPacket;
-import java.net.InetSocketAddress;
 
 /**
  * Extension of DatagramFilter

--- a/scandium-core/src/main/java/org/eclipse/californium/scandium/DatagramFilterExtended.java
+++ b/scandium-core/src/main/java/org/eclipse/californium/scandium/DatagramFilterExtended.java
@@ -21,18 +21,20 @@ import org.eclipse.californium.scandium.dtls.Record;
 import java.net.DatagramPacket;
 
 /**
- * Extension of DatagramFilter
+ * Extension of DatagramFilter.
+ *
+ * @since 3.8
  */
 @PublicAPIExtension(type = DatagramFilter.class)
 public interface DatagramFilterExtended {
 
 	/**
-	 * Called when a datagram packed is dropped. Allows to inject packet based action in form of callback
+	 * Called when a datagram packed is dropped. Allows to inject packet based action in form of callback.
 	 * @param packet the dropped datagram packet
 	 */
 	void onDrop(DatagramPacket packet);
 	/**
-	 * Called when a record is dropped. Allows to inject record based action in form of callback
+	 * Called when a record is dropped. Allows to inject record based action in form of callback.
 	 * @param record the dropped record
 	 */
 	void onDrop(Record record);


### PR DESCRIPTION
Discussion ref: #2099 

I'd like to introduce injectable action on datagram/record drop with access to dropped object. As discussed in the issue two methods were prepared to be added to `DatagramFilter`.