### PR TITLE
Explain GitHub security advisories

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -2,9 +2,11 @@
 
 ## Reporting a Vulnerability
 
-Californium supports the use of [GitHub security advisories](https://help.github.com/en/articles/managing-security-vulnerabilities-in-your-project) as pilot for [eclipse](https://www.eclipse.org/) projects. Please consider to use it for reporting vulnerabilities.
+Californium supports the use of [GitHub security advisories](https://help.github.com/en/articles/managing-security-vulnerabilities-in-your-project) as pilot for [eclipse](https://www.eclipse.org/) projects.
 
-Alternatively may also report a vulnerability opening a [bugzilla ticket](https://bugs.eclipse.org/bugs/enter_bug.cgi?product=Community&component=Vulnerability+Reports&keywords=security&groups=Security_Advisories).
+To report a vulnerability, [go directly to the form](https://github.com/eclipse-californium/californium/security/advisories/new). Alternatively, switch to the [Security tab](https://github.com/eclipse-californium/californium/security), then click "Report a vulnerability" and another "Report a vulnerability" button again.
+
+You may also report a vulnerability opening a [bugzilla ticket](https://bugs.eclipse.org/bugs/enter_bug.cgi?product=Community&component=Vulnerability+Reports&keywords=security&groups=Security_Advisories).
 
 For more details, please look at [https://www.eclipse.org/security](https://www.eclipse.org/security).
 


### PR DESCRIPTION
Add direct link to the form to report a new security issue in GitHub security advisories and explain how to access that form.

The goal is to make reporting even easier.

Signed-off-by: Marta Rybczynska <marta.rybczynska@eclipse-foundation.org>