### PR TITLE
coap-over-tcp: cancel all observation relations on send errors.

### DIFF
--- a/californium-core/src/main/java/org/eclipse/californium/core/CoapObserveRelation.java
+++ b/californium-core/src/main/java/org/eclipse/californium/core/CoapObserveRelation.java
@@ -122,7 +122,8 @@ public class CoapObserveRelation extends ClientObserveRelation {
 	/**
 	 * Sets the current response or notification.
 	 *
-	 * Use {@link #orderer} to filter deprecated responses.
+	 * Use {@link #orderer} to filter deprecated responses over UDP.
+	 * Responses over TCP are already in order.
 	 *
 	 * @param response the response or notification
 	 * @return {@code true}, response is accepted by {@link #orderer},

--- a/californium-core/src/main/java/org/eclipse/californium/core/coap/ClientObserveRelation.java
+++ b/californium-core/src/main/java/org/eclipse/californium/core/coap/ClientObserveRelation.java
@@ -386,7 +386,11 @@ public class ClientObserveRelation {
 	 * @return {@code true}, if matched, {@code false}, if not.
 	 */
 	public boolean matchRequest(Request request) {
-		return this.request.getToken().equals(request.getToken());
+		// the client observe relation is created
+		// before the token is assigned sending the 
+		// request.
+		Token token = this.request.getToken();
+		return token != null && token.equals(request.getToken());
 	}
 
 	private void setReregistrationHandle(ScheduledFuture<?> reregistrationHandle) {

--- a/californium-core/src/main/java/org/eclipse/californium/core/network/TcpMatcher.java
+++ b/californium-core/src/main/java/org/eclipse/californium/core/network/TcpMatcher.java
@@ -126,7 +126,7 @@ public final class TcpMatcher extends BaseMatcher {
 
 				@Override
 				public void onSendError(Throwable error) {
-					observeRelation.cancel();
+					observeRelation.cancelAll();
 				}
 			});
 		}

--- a/californium-core/src/main/java/org/eclipse/californium/core/network/TcpMatcher.java
+++ b/californium-core/src/main/java/org/eclipse/californium/core/network/TcpMatcher.java
@@ -197,8 +197,13 @@ public final class TcpMatcher extends BaseMatcher {
 				EndpointContext context = exchange.getEndpointContext();
 				if (context == null) {
 					// ignore response
-					LOGGER.error("ignoring response from [{}]: {}, request pending to sent!",
-							response.getSourceContext(), response);
+					if (response.isNotification()) {
+						LOGGER.debug("ignoring response from [{}]: {}, current request pending to sent!",
+								response.getSourceContext(), response);
+					} else {
+						LOGGER.error("ignoring response from [{}]: {}, request pending to sent!",
+								response.getSourceContext(), response);
+					}
 					cancel(response, receiver);
 					return;
 				}

--- a/californium-core/src/main/java/org/eclipse/californium/core/observe/ObserveNotificationOrderer.java
+++ b/californium-core/src/main/java/org/eclipse/californium/core/observe/ObserveNotificationOrderer.java
@@ -111,4 +111,15 @@ public class ObserveNotificationOrderer {
 			return false;
 		}
 	}
+
+	/**
+	 * Reset state.
+	 * 
+	 * @since 3.8
+	 */
+	public synchronized void reset() {
+		number.set(0);
+		nanoTimestamp = 0;
+	}
+
 }

--- a/californium-core/src/main/java/org/eclipse/californium/core/observe/ObserveStatisticLogger.java
+++ b/californium-core/src/main/java/org/eclipse/californium/core/observe/ObserveStatisticLogger.java
@@ -65,7 +65,7 @@ public class ObserveStatisticLogger extends CounterStatisticManager implements O
 		try {
 			if (isEnabled()) {
 				if (LOGGER.isDebugEnabled()) {
-					if (observes.isUsed()) {
+					if (observeRequests.isUsed()) {
 						StringBuilder log = new StringBuilder();
 						String eol = StringUtil.lineSeparator();
 						String head = "   " + tag;
@@ -74,7 +74,7 @@ public class ObserveStatisticLogger extends CounterStatisticManager implements O
 						log.append(head).append(endpoints).append(eol);
 						log.append(head).append(observeRequests).append(eol);
 						log.append(head).append(cancelRequests).append(eol);
-						log.append(tag).append(rejectedNotifies);
+						log.append(head).append(rejectedNotifies);
 						LOGGER.debug("{}", log);
 					}
 				}

--- a/element-connector-tcp-netty/pom.xml
+++ b/element-connector-tcp-netty/pom.xml
@@ -15,9 +15,9 @@
 
 	<name>Californium (Cf) Element Connector TCP netty</name>
 	<description>Element connector implementation for TCP/TLS using netty</description>
-	
+
 	<properties>
-		<netty.version>4.1.86.Final</netty.version>
+		<netty.version>4.1.87.Final</netty.version>
 		<netty.version.spec>
 			version="[${versionmask;==;${netty.version}},${versionmask;+;${netty.version}})"
 		</netty.version.spec>


### PR DESCRIPTION
Add caching of principal and session-id to TLS.
Update netty.io to 4.1.87.Final.

Signed-off-by: Achim Kraus <achim.kraus@cloudcoap.net>