### PR TITLE
Experimentally relax the constraints of the exchange executor.

### DIFF
--- a/element-connector/src/main/java/org/eclipse/californium/elements/util/CheckedExecutor.java
+++ b/element-connector/src/main/java/org/eclipse/californium/elements/util/CheckedExecutor.java
@@ -1,0 +1,43 @@
+/********************************************************************************
+ * Copyright (c) 2023 Contributors to the Eclipse Foundation
+ * 
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ * 
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * https://www.eclipse.org/legal/epl-2.0, or the Eclipse Distribution License
+ * v1.0 which is available at
+ * https://www.eclipse.org/org/documents/edl-v10.php.
+ * 
+ * SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
+ ********************************************************************************/
+package org.eclipse.californium.elements.util;
+
+import java.util.ConcurrentModificationException;
+import java.util.concurrent.Executor;
+
+/**
+ * Checked owner executor.
+ * 
+ * @since 3.9
+ */
+public interface CheckedExecutor extends Executor {
+
+	/**
+	 * Assert, that the current thread executes the current job.
+	 * 
+	 * @throws ConcurrentModificationException if current thread doesn't execute
+	 *             the current job
+	 */
+	void assertOwner();
+
+	/**
+	 * Check, if current thread executes the current job.
+	 * 
+	 * @return {@code true}, if current thread executes the current job,
+	 *         {@code false}, otherwise.
+	 */
+	boolean checkOwner();
+
+}

--- a/element-connector/src/main/java/org/eclipse/californium/elements/util/SerialExecutor.java
+++ b/element-connector/src/main/java/org/eclipse/californium/elements/util/SerialExecutor.java
@@ -37,7 +37,7 @@ import org.slf4j.LoggerFactory;
  * 
  * Serialize job execution before passing the jobs to a provided executor.
  */
-public class SerialExecutor extends AbstractExecutorService {
+public class SerialExecutor extends AbstractExecutorService implements CheckedExecutor {
 
 	private static final Logger LOGGER = LoggerFactory.getLogger(SerialExecutor.class);
 
@@ -119,12 +119,11 @@ public class SerialExecutor extends AbstractExecutorService {
 	}
 
 	/**
-	 * Assert, that the current thread executes the
-	 * {@link #currentlyExecutedJob}.
+	 * {@inheritDoc}
 	 * 
-	 * @throws ConcurrentModificationException if current thread doesn't execute
-	 *             the {@link #currentlyExecutedJob}.
-	 */
+	 * {@link #currentlyExecutedJob} is used for the current job.
+		 */
+	@Override
 	public void assertOwner() {
 		final Thread me = Thread.currentThread();
 		if (owner.get() != me) {
@@ -138,11 +137,11 @@ public class SerialExecutor extends AbstractExecutorService {
 	}
 
 	/**
-	 * Check, if current thread executes the {@link #currentlyExecutedJob}.
+	 * {@inheritDoc}
 	 * 
-	 * @return {@code true}, if current thread executes the
-	 *         {@link #currentlyExecutedJob}, {@code false}, otherwise.
-	 */
+	 * {@link #currentlyExecutedJob} is used for the current job.
+		 */
+	@Override
 	public boolean checkOwner() {
 		return owner.get() == Thread.currentThread();
 	}


### PR DESCRIPTION
Don't fail, when a null executor is passed in.
Still not supported and may fail later, including hard to find race conditions.