### PR TITLE
Add request message code to blockwise tracking.

### DIFF
--- a/californium-core/src/main/java/org/eclipse/californium/core/network/stack/BlockwiseLayer.java
+++ b/californium-core/src/main/java/org/eclipse/californium/core/network/stack/BlockwiseLayer.java
@@ -1520,7 +1520,7 @@ public class BlockwiseLayer extends AbstractLayer {
 			lock.unlock();
 		}
 		if (size != null) {
-			LOGGER.debug("{}created tracker for {} inbound block2 transfer {}, transfers in progress: {}, {}", tag, key,
+			LOGGER.debug("{}created tracker for inbound block2 transfer {}, transfers in progress: {}, {}", tag, 
 					status, size, response);
 		}
 		return status;

--- a/californium-core/src/main/java/org/eclipse/californium/core/network/stack/KeyUri.java
+++ b/californium-core/src/main/java/org/eclipse/californium/core/network/stack/KeyUri.java
@@ -19,6 +19,7 @@ package org.eclipse.californium.core.network.stack;
 
 import java.net.InetSocketAddress;
 
+import org.eclipse.californium.core.coap.CoAP.Code;
 import org.eclipse.californium.core.coap.Request;
 import org.eclipse.californium.core.network.Exchange;
 import org.eclipse.californium.elements.util.StringUtil;
@@ -28,10 +29,13 @@ import org.eclipse.californium.elements.util.StringUtil;
  * address.
  * <p>
  * This class is used by the blockwise layer to correlate blockwise transfer
- * exchanges.
+ * exchanges. 
+ * <p>
+ * Note: since 3.9, the message code is also used part of the key.
  */
 public final class KeyUri {
 
+	private final Code code;
 	private final String uri;
 	private final Object peersIdentity;
 	private final int hash;
@@ -44,16 +48,37 @@ public final class KeyUri {
 	 *            {@link InetSocketAddress}.
 	 * @throws NullPointerException if uri or address is {@code null}
 	 * @since 3.0
+	 * @deprecated use KeyUri(String, Object, Code) instead
 	 */
-	public KeyUri(final String requestUri, final Object peersIdentity) {
+	@Deprecated
+	public KeyUri(String requestUri, Object peersIdentity) {
+		this(requestUri, peersIdentity, null);
+	}
+
+	/**
+	 * Creates a new key for a URI scoped to an endpoint address.
+	 * 
+	 * @param requestUri The URI of the requested resource.
+	 * @param peersIdentity peer's identity. Usually that's the peer's
+	 *            {@link InetSocketAddress}.
+	 * @param code message code. {@code null} for ping request.
+	 * @throws NullPointerException if uri or address is {@code null}
+	 * @since 3.9
+	 */
+	public KeyUri(String requestUri, Object peersIdentity, Code code) {
 		if (requestUri == null) {
 			throw new NullPointerException("URI must not be null");
 		} else if (peersIdentity == null) {
 			throw new NullPointerException("peer's identity must not be null");
 		} else {
+			this.code = code;
 			this.uri = requestUri;
 			this.peersIdentity = peersIdentity;
-			this.hash = requestUri.hashCode() * 31 + peersIdentity.hashCode();
+			int hash = requestUri.hashCode() * 31 + peersIdentity.hashCode();
+			if (code != null) {
+				hash = hash * 31 + code.hashCode();
+			}
+			this.hash = hash;
 		}
 	}
 
@@ -75,6 +100,9 @@ public final class KeyUri {
 		if (!uri.equals(other.uri)) {
 			return false;
 		}
+		if (code != other.code && !code.equals(other.code)) {
+			return false;
+		}
 		return true;
 	}
 
@@ -86,7 +114,7 @@ public final class KeyUri {
 	@Override
 	public String toString() {
 		StringBuilder b = new StringBuilder("KeyUri[");
-		b.append(uri);
+		b.append(code).append(", ").append(uri);
 		Object peer = this.peersIdentity;
 		if (peer instanceof InetSocketAddress) {
 			peer = StringUtil.toDisplayString((InetSocketAddress) peer);
@@ -124,8 +152,10 @@ public final class KeyUri {
 		if (exchange == null) {
 			throw new NullPointerException("exchange must not be null");
 		}
-		String uri = getUri(exchange.getRequest());
-		return new KeyUri(uri, exchange.getPeersIdentity());
+		Request request = exchange.getRequest();
+		String uri = getUri(request);
+		Code code = request.getCode();
+			return new KeyUri(uri, exchange.getPeersIdentity(), code);
 	}
 
 }


### PR DESCRIPTION
Disables test for OSCORE outer blockwise GET.