### PR TITLE
fix(sec): upgrade io.netty:netty-handler to 4.1.94.final

### DIFF
--- a/element-connector-tcp-netty/pom.xml
+++ b/element-connector-tcp-netty/pom.xml
@@ -17,7 +17,7 @@
 	<description>Element connector implementation for TCP/TLS using netty</description>
 
 	<properties>
-		<netty.version>4.1.94.Final</netty.version>
+		<netty.version>4.1.94.final</netty.version>
 		<netty.version.spec>
 			version="[${versionmask;==;${netty.version}},${versionmask;+;${netty.version}})"
 		</netty.version.spec>


### PR DESCRIPTION
### What happened？
There are 1 security vulnerabilities found in io.netty:netty-handler 4.1.94.Final
- [CVE-2023-34462](https://www.oscs1024.com/hd/CVE-2023-34462)


### What did I do？
Upgrade io.netty:netty-handler from 4.1.94.Final to 4.1.94.final for vulnerability fix

### What did you expect to happen？
Ideally, no insecure libs should be used.

### How can we automate the detection of these types of issues?
By using the [GitHub Actions](https://github.com/murphysecurity/actions) configurations provided by murphysec, we can conduct automatic code security checks in our CI pipeline.

### The specification of the pull request
[PR Specification](https://www.oscs1024.com/docs/pr-specification/) from OSCS