### PR TITLE
OSCORE: Improvements to functionality for secure context re-generation

### DIFF
--- a/cf-oscore/src/main/java/org/eclipse/californium/oscore/Decryptor.java
+++ b/cf-oscore/src/main/java/org/eclipse/californium/oscore/Decryptor.java
@@ -34,6 +34,7 @@ import com.upokecenter.cbor.CBORObject;
 import org.eclipse.californium.cose.Attribute;
 import org.eclipse.californium.cose.CoseException;
 import org.eclipse.californium.cose.HeaderKeys;
+import org.eclipse.californium.oscore.ContextRederivation.PHASE;
 
 /**
  * 
@@ -126,6 +127,12 @@ public abstract class Decryptor {
 			//Nonce calculation uses partial IV in response (if present).
 			//AAD calculation always uses partial IV (seq. nr.) of original request.  
 			aad = OSSerializer.serializeAAD(CoAP.VERSION, ctx.getAlg(), seq, ctx.getSenderId(), message.getOptions());
+		}
+
+		if (ctx.getContextRederivationPhase() == PHASE.SERVER_PHASE_1) {
+			ctx.setNonceHandover(nonce);
+		} else if (ctx.getContextRederivationPhase() == PHASE.CLIENT_PHASE_2 && ctx.getNonceHandover() != null) {
+			nonce = ctx.getNonceHandover();
 		}
 
 		byte[] plaintext = null;

--- a/cf-oscore/src/main/java/org/eclipse/californium/oscore/Encryptor.java
+++ b/cf-oscore/src/main/java/org/eclipse/californium/oscore/Encryptor.java
@@ -34,6 +34,7 @@ import com.upokecenter.cbor.CBORObject;
 import org.eclipse.californium.cose.Attribute;
 import org.eclipse.californium.cose.CoseException;
 import org.eclipse.californium.cose.HeaderKeys;
+import org.eclipse.californium.oscore.ContextRederivation.PHASE;
 
 /**
  * 
@@ -96,6 +97,13 @@ public abstract class Encryptor {
 
 				aad = OSSerializer.serializeAAD(CoAP.VERSION, ctx.getAlg(), requestSequenceNr, ctx.getRecipientId(),
 						message.getOptions());
+			}
+
+			if (ctx.getContextRederivationPhase() == PHASE.SERVER_PHASE_2 && ctx.getNonceHandover() != null) {
+				nonce = ctx.getNonceHandover();
+			} else if (ctx.getContextRederivationPhase() == PHASE.CLIENT_PHASE_1
+					|| ctx.getContextRederivationPhase() == PHASE.INACTIVE) {
+				ctx.setNonceHandover(nonce);
 			}
 
 			enc.setExternal(aad);

--- a/cf-oscore/src/main/java/org/eclipse/californium/oscore/OSCoreCtx.java
+++ b/cf-oscore/src/main/java/org/eclipse/californium/oscore/OSCoreCtx.java
@@ -923,4 +923,29 @@ public class OSCoreCtx {
 	private static byte[] createByteArray(byte... values) {
 		return values;
 	}
+
+	/**
+	 * Holds nonce to hand over between different Security Contexts during
+	 * execution of Appendix B.2
+	 */
+	private byte[] nonceHandover;
+
+	/**
+	 * Set nonce to hand over during execution of Appendix B.2
+	 * 
+	 * @param nonce the nonce value to hand over
+	 */
+	protected void setNonceHandover(byte[] nonce) {
+		this.nonceHandover = nonce;
+	}
+
+	/**
+	 * Get nonce for hand over during execution of Appendix B.2
+	 * 
+	 * @return the retrieved nonce value
+	 */
+	protected byte[] getNonceHandover() {
+		return nonceHandover;
+	}
+
 }

--- a/cf-oscore/src/test/java/org/eclipse/californium/oscore/ContextRederivationTest.java
+++ b/cf-oscore/src/test/java/org/eclipse/californium/oscore/ContextRederivationTest.java
@@ -275,8 +275,8 @@ public class ContextRederivationTest {
 		assertArrayEquals(contextR2, oscoreOptionR2);
 		assertArrayEquals(hmacOutput, messageHmacValue);
 
-		assertEquals(ResponseCode.CONTENT, resp.getCode());
-		assertEquals(SERVER_RESPONSE, resp.getResponseText());
+		// The response should be a 4.01
+		assertEquals(ResponseCode.UNAUTHORIZED, resp.getCode());
 
 		// 2nd request (for request #2 and response #2 exchange)
 		request = new Request(Code.GET);


### PR DESCRIPTION
Two modifications have been done to the Appendix B.2 functionality for securely re-generating contexts:
- Ensure that for responses the server uses the nonce from the request
- Make it so response 1 has response code 4.01 Unauthorized