### PR TITLE
OSCORE: Link target attribute

### DIFF
--- a/californium-core/src/main/java/org/eclipse/californium/core/coap/LinkFormat.java
+++ b/californium-core/src/main/java/org/eclipse/californium/core/coap/LinkFormat.java
@@ -51,6 +51,7 @@ public class LinkFormat {
 	public static final String TITLE = "title";
 	public static final String OBSERVABLE = "obs";
 	public static final String LINK = "href";
+	public static final String OSCOREONLY = "osc"; // RFC 8613
 
 	// for Resource Directory
 	public static final String LIFE_TIME = "lt";

--- a/californium-core/src/main/java/org/eclipse/californium/core/server/resources/ResourceAttributes.java
+++ b/californium-core/src/main/java/org/eclipse/californium/core/server/resources/ResourceAttributes.java
@@ -252,6 +252,34 @@ public class ResourceAttributes {
 	}
 
 	/**
+	 * Marks the resource as only accessible using OSCORE.
+	 *
+	 * @since 3.10
+	 */
+	public void setOscoreOnly() {
+		findAttributeValues(LinkFormat.OSCOREONLY).setOnly("");
+	}
+
+	/**
+	 * Checks if the resource is only accessible using OSCORE.
+	 *
+	 * @return {@code true}, if only accessible using OSCORE
+	 * @since 3.10
+	 */
+	public boolean hasOscoreOnly() {
+		return hasAttribute(LinkFormat.OSCOREONLY);
+	}
+
+	/**
+	 * Marks the resource as not only accessible using OSCORE.
+	 *
+	 * @since 3.10
+	 */
+	public void clearOscoreOnly() {
+		attributes.remove(LinkFormat.OSCOREONLY);
+	}
+
+	/**
 	 * Replaces the value for the specified attribute with the specified value.
 	 * If another value has been set for the attribute name, it will be removed.
 	 * 

--- a/cf-oscore/src/main/java/org/eclipse/californium/oscore/ErrorDescriptions.java
+++ b/cf-oscore/src/main/java/org/eclipse/californium/oscore/ErrorDescriptions.java
@@ -60,6 +60,7 @@ public final class ErrorDescriptions {
 	public static final String CONTEXT_NULL = "Context is null";
 	public static final String ALGORITHM_NOT_DEFINED = "Algorithm not defined";
 	public static final String CONTEXT_REGENERATION_FAILED = "Security context re-generation failed";
+	public static final String OSCORE_ONLY_RESOURCE = "The resource is only accessible using OSCORE";
 
 	public static final String CANNOT_CREATE_ERROR_MESS = "Cannot create error message for this error";
 

--- a/cf-oscore/src/main/java/org/eclipse/californium/oscore/OSCoreResource.java
+++ b/cf-oscore/src/main/java/org/eclipse/californium/oscore/OSCoreResource.java
@@ -12,13 +12,13 @@
  * 
  * Contributors:
  *    Tobias Andersson (RISE SICS)
+ *    Rikard Höglund (RISE)
  *    
  ******************************************************************************/
 package org.eclipse.californium.oscore;
 
 import org.eclipse.californium.core.CoapResource;
 import org.eclipse.californium.core.coap.CoAP.ResponseCode;
-import org.eclipse.californium.core.coap.CoAP.Type;
 import org.eclipse.californium.core.network.Exchange;
 import org.eclipse.californium.core.coap.OptionSet;
 import org.eclipse.californium.core.coap.Response;
@@ -34,6 +34,9 @@ public class OSCoreResource extends CoapResource {
 
 	public OSCoreResource(String name, final boolean isProtected) {
 		super(name);
+		if (isProtected) {
+			getAttributes().setOscoreOnly();
+		}
 		this.isProtected = isProtected;
 	}
 
@@ -43,7 +46,7 @@ public class OSCoreResource extends CoapResource {
 			OptionSet options = exchange.getRequest().getOptions();
 			if (!options.hasOscore()) {
 				Response r = new Response(ResponseCode.UNAUTHORIZED);
-				r.setType(Type.RST);
+				r.setPayload(ErrorDescriptions.OSCORE_ONLY_RESOURCE);
 				exchange.sendResponse(r);
 				return;
 			}


### PR DESCRIPTION
This PR adds the link target attribute 'osc' for resources which are only accessible using OSCORE.

It also corrects the behavior of the _OSCoreResource_ when it is set to only be accessible using OSCORE, but receives a non-OSCORE request.