### PR TITLE
correct authenticationmode description syntax error

### DIFF
--- a/cf-utils/cf-cli/src/main/java/org/eclipse/californium/cli/ConnectorConfig.java
+++ b/cf-utils/cf-cli/src/main/java/org/eclipse/californium/cli/ConnectorConfig.java
@@ -351,7 +351,7 @@ public class ConnectorConfig implements Cloneable {
 	 * List of authentication modes (ordered by preference).
 	 */
 	@Option(names = { "-a",
-			"--auth" }, split = ":", description = "use authentikation modes. '--help-auth' to list available authentication modes.")
+			"--auth" }, split = ":", description = "use authentication modes. '--help-auth' to list available authentication modes.")
 	public List<AuthenticationMode> authenticationModes;
 
 	/**


### PR DESCRIPTION
origin:

```java
/**
 * List of authentication modes (ordered by preference).
 */
@Option(names = { "-a",
"--auth" }, split = ":", description = "use authentikation modes. '--help-auth' to list available authentication modes.")
public List<AuthenticationMode> authenticationModes;
```

Syntax error exists