### PR TITLE
Deprecate exposed logger and replace them by local instances.

### DIFF
--- a/californium-core/src/main/java/org/eclipse/californium/core/CoapResource.java
+++ b/californium-core/src/main/java/org/eclipse/californium/core/CoapResource.java
@@ -136,7 +136,12 @@ import org.slf4j.LoggerFactory;
 @SuppressWarnings("deprecation")
 public class CoapResource implements Resource, ObservableResource {
 
-	/** The logger. */
+	/**
+	 * The logger.
+	 * 
+	 * @deprecated scope will change to private
+	 */
+	@Deprecated
 	protected final static Logger LOGGER = LoggerFactory.getLogger(CoapResource.class);
 
 	/**

--- a/californium-core/src/main/java/org/eclipse/californium/core/CoapServer.java
+++ b/californium-core/src/main/java/org/eclipse/californium/core/CoapServer.java
@@ -126,7 +126,12 @@ public class CoapServer implements ServerInterface, PersistentComponentProvider 
 	 */
 	private static final String MARK = "CoAP";
 
-	/** The logger. */
+	/**
+	 * The logger.
+	 * 
+	 * @deprecated scope will change to private
+	 */
+	@Deprecated
 	protected static final Logger LOGGER = LoggerFactory.getLogger(CoapServer.class);
 
 	/** The root resource. */

--- a/californium-core/src/main/java/org/eclipse/californium/core/coap/Message.java
+++ b/californium-core/src/main/java/org/eclipse/californium/core/coap/Message.java
@@ -88,7 +88,12 @@ import org.slf4j.LoggerFactory;
  * @see EmptyMessage
  */
 public abstract class Message {
-
+	/**
+	 * The logger.
+	 * 
+	 * @deprecated scope will change to private
+	 */
+	@Deprecated
 	protected final static Logger LOGGER = LoggerFactory.getLogger(Message.class);
 
 	/**

--- a/californium-core/src/main/java/org/eclipse/californium/core/coap/Request.java
+++ b/californium-core/src/main/java/org/eclipse/californium/core/coap/Request.java
@@ -61,6 +61,8 @@ import org.eclipse.californium.elements.EndpointContext;
 import org.eclipse.californium.elements.util.ClockUtil;
 import org.eclipse.californium.elements.util.NetworkInterfacesUtil;
 import org.eclipse.californium.elements.util.StringUtil;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * Request represents a CoAP request and has either the {@link Type} CON or NON
@@ -173,6 +175,10 @@ import org.eclipse.californium.elements.util.StringUtil;
  * @see Response
  */
 public class Request extends Message {
+	/**
+	 * @since 3.10
+	 */
+	private static final Logger LOG = LoggerFactory.getLogger(Request.class);
 
 	/**
 	 * The request code.
@@ -440,7 +446,7 @@ public class Request extends Message {
 			String coapUri = uri;
 			if (!uri.contains("://")) {
 				coapUri = "coap://" + uri;
-				LOGGER.warn("update your code to supply an RFC 7252 compliant URI including a scheme");
+				LOG.warn("update your code to supply an RFC 7252 compliant URI including a scheme");
 			}
 			return setURI(new URI(coapUri));
 		} catch (URISyntaxException e) {
@@ -608,7 +614,7 @@ public class Request extends Message {
 					}
 				} catch (UnknownHostException e) {
 					// this should not happen because we do not need to resolve a host name
-					LOGGER.warn("could not parse IP address of URI despite successful IP address pattern matching");
+					LOG.warn("could not parse IP address of URI despite successful IP address pattern matching");
 				}
 			} else {
 				if (!StringUtil.isValidHostName(host)) {

--- a/californium-core/src/main/java/org/eclipse/californium/core/network/stack/ReliabilityLayer.java
+++ b/californium-core/src/main/java/org/eclipse/californium/core/network/stack/ReliabilityLayer.java
@@ -62,7 +62,12 @@ import org.slf4j.LoggerFactory;
  */
 public class ReliabilityLayer extends AbstractLayer {
 
-	/** The logger. */
+	/**
+	 * The logger.
+	 * 
+	 * @deprecated scope will change to private
+	 */
+	@Deprecated
 	protected final static Logger LOGGER = LoggerFactory.getLogger(ReliabilityLayer.class);
 
 	protected final ReliabilityLayerParameters defaultReliabilityLayerParameters;

--- a/californium-core/src/main/java/org/eclipse/californium/core/network/stack/congestioncontrol/LinuxRto.java
+++ b/californium-core/src/main/java/org/eclipse/californium/core/network/stack/congestioncontrol/LinuxRto.java
@@ -20,8 +20,14 @@ package org.eclipse.californium.core.network.stack.congestioncontrol;
 import org.eclipse.californium.core.network.stack.CongestionControlLayer;
 import org.eclipse.californium.core.network.stack.RemoteEndpoint;
 import org.eclipse.californium.elements.config.Configuration;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 public class LinuxRto extends CongestionControlLayer {
+	/**
+	 * @since 3.10
+	 */
+	private static final Logger LOG = LoggerFactory.getLogger(LinuxRto.class);
 
 	public LinuxRto(String tag, Configuration config) {
 		super(tag, config);
@@ -104,7 +110,7 @@ public class LinuxRto extends CongestionControlLayer {
 		}
 
 		private void printLinuxStats() {
-			LOGGER.trace("SRTT: {}, RTTVAR: {}, mdev: {}, mdev_max: {}", SRTT, RTTVAR, mdev, mdev_max);
+			LOG.trace("SRTT: {}, RTTVAR: {}, mdev: {}, mdev_max: {}", SRTT, RTTVAR, mdev, mdev_max);
 		}
 	}
 }

--- a/californium-core/src/main/java/org/eclipse/californium/core/network/stack/congestioncontrol/PeakhopperRto.java
+++ b/californium-core/src/main/java/org/eclipse/californium/core/network/stack/congestioncontrol/PeakhopperRto.java
@@ -20,8 +20,14 @@ package org.eclipse.californium.core.network.stack.congestioncontrol;
 import org.eclipse.californium.core.network.stack.CongestionControlLayer;
 import org.eclipse.californium.core.network.stack.RemoteEndpoint;
 import org.eclipse.californium.elements.config.Configuration;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 public class PeakhopperRto extends CongestionControlLayer {
+	/**
+	 * @since 3.10
+	 */
+	private static final Logger LOG = LoggerFactory.getLogger(PeakhopperRto.class);
 
 	public PeakhopperRto(String tag, Configuration config) {
 		super(tag, config);
@@ -115,7 +121,7 @@ public class PeakhopperRto extends CongestionControlLayer {
 		}
 
 		private void printPeakhopperStats() {
-			LOGGER.trace("Delta: {}, D: {}, B: {}, RTT_max: {}", delta, D_value, B_value, RTT_max);
+			LOG.trace("Delta: {}, D: {}, B: {}, RTT_max: {}", delta, D_value, B_value, RTT_max);
 		}
 	}
 }

--- a/cf-utils/cf-cluster/src/main/java/org/eclipse/californium/cluster/K8sManagementClient.java
+++ b/cf-utils/cf-cluster/src/main/java/org/eclipse/californium/cluster/K8sManagementClient.java
@@ -108,8 +108,11 @@ public abstract class K8sManagementClient {
 	private static final String KUBECTL_NAMESPACE = "KUBECTL_NAMESPACE";
 
 	/**
-	 * Logger.
+	 * The logger.
+	 * 
+	 * @deprecated scope will change to private.
 	 */
+	@Deprecated
 	protected static final Logger LOGGER = LoggerFactory.getLogger(K8sManagementClient.class);
 	/**
 	 * Hostname.

--- a/cf-utils/cf-unix-health/src/main/java/org/eclipse/californium/unixhealth/NetSocketHealthLogger.java
+++ b/cf-utils/cf-unix-health/src/main/java/org/eclipse/californium/unixhealth/NetSocketHealthLogger.java
@@ -48,7 +48,12 @@ import org.slf4j.LoggerFactory;
 @NotForAndroid
 public class NetSocketHealthLogger extends CounterStatisticManager {
 
-	/** the logger. */
+	/**
+	 * The logger.
+	 * 
+	 * @deprecated scope will change to private.
+	 */
+	@Deprecated
 	protected static final Logger LOGGER = LoggerFactory.getLogger(NetSocketHealthLogger.class);
 
 	/**

--- a/cf-utils/cf-unix-health/src/main/java/org/eclipse/californium/unixhealth/NetStatLogger.java
+++ b/cf-utils/cf-unix-health/src/main/java/org/eclipse/californium/unixhealth/NetStatLogger.java
@@ -41,7 +41,12 @@ import org.slf4j.LoggerFactory;
 @NotForAndroid
 public class NetStatLogger extends CounterStatisticManager {
 
-	/** the logger. */
+	/**
+	 * The logger.
+	 * 
+	 * @deprecated scope will change to private.
+	 */
+	@Deprecated
 	protected static final Logger LOGGER = LoggerFactory.getLogger(NetStatLogger.class);
 
 	// Udp: InDatagrams NoPorts InErrors OutDatagrams RcvbufErrors SndbufErrors

--- a/demo-apps/cf-extplugtest-client/src/main/java/org/eclipse/californium/extplugtests/BenchmarkClient.java
+++ b/demo-apps/cf-extplugtest-client/src/main/java/org/eclipse/californium/extplugtests/BenchmarkClient.java
@@ -412,8 +412,8 @@ public class BenchmarkClient {
 	private static final long DEFAULT_TIMEOUT_NANOS = TimeUnit.SECONDS.toNanos(DEFAULT_TIMEOUT_SECONDS);
 	private static final long DTLS_TIMEOUT_NANOS = TimeUnit.SECONDS.toNanos(120);
 
-	private static final FilteredLogger errorResponseFilter = new FilteredLogger(LOGGER, 5, DEFAULT_TIMEOUT_NANOS);
-	private static final FilteredLogger errorFilter = new FilteredLogger(LOGGER, 3, DEFAULT_TIMEOUT_NANOS);
+	private static final FilteredLogger errorResponseFilter = new FilteredLogger(LOGGER.getName(), 5, DEFAULT_TIMEOUT_NANOS);
+	private static final FilteredLogger errorFilter = new FilteredLogger(LOGGER.getName(), 3, DEFAULT_TIMEOUT_NANOS);
 
 	/**
 	 * Atomic down-counter for overall requests.

--- a/demo-apps/cf-extplugtest-client/src/main/java/org/eclipse/californium/extplugtests/resources/Feed.java
+++ b/demo-apps/cf-extplugtest-client/src/main/java/org/eclipse/californium/extplugtests/resources/Feed.java
@@ -55,7 +55,7 @@ public class Feed extends CoapResource {
 
 	private static final Logger LOGGER = LoggerFactory.getLogger(Feed.class);
 
-	private static final FilteredLogger ERROR_FILTER = new FilteredLogger(LOGGER, 3, TimeUnit.SECONDS.toNanos(10));
+	private static final FilteredLogger ERROR_FILTER = new FilteredLogger(LOGGER.getName(), 3, TimeUnit.SECONDS.toNanos(10));
 
 	/**
 	 * Resource name.

--- a/demo-apps/cf-extplugtest-server/src/main/java/org/eclipse/californium/extplugtests/ExtendedTestServer.java
+++ b/demo-apps/cf-extplugtest-server/src/main/java/org/eclipse/californium/extplugtests/ExtendedTestServer.java
@@ -117,6 +117,10 @@ import picocli.CommandLine.ParseResult;
  * statistic resource.
  */
 public class ExtendedTestServer extends AbstractTestServer {
+	/**
+	 * @since 3.10
+	 */
+	private static final Logger LOGGER = LoggerFactory.getLogger(CoapServer.class);
 
 	private static final Logger STATISTIC_LOGGER = LoggerFactory
 			.getLogger("org.eclipse.californium.extplugtests.statistics");

--- a/demo-apps/cf-plugtest-server/src/main/java/org/eclipse/californium/plugtests/AbstractTestServer.java
+++ b/demo-apps/cf-plugtest-server/src/main/java/org/eclipse/californium/plugtests/AbstractTestServer.java
@@ -81,6 +81,11 @@ import org.slf4j.LoggerFactory;
  */
 public abstract class AbstractTestServer extends CoapServer {
 
+	/**
+	 * @since 3.10
+	 */
+	private static final Logger LOGGER = LoggerFactory.getLogger(CoapServer.class);
+
 	public enum Protocol {
 		UDP, DTLS, TCP, TLS
 	}

--- a/demo-apps/cf-plugtest-server/src/main/java/org/eclipse/californium/plugtests/PlugtestServer.java
+++ b/demo-apps/cf-plugtest-server/src/main/java/org/eclipse/californium/plugtests/PlugtestServer.java
@@ -99,6 +99,8 @@ import org.eclipse.californium.scandium.dtls.cipher.CipherSuite;
 import org.eclipse.californium.scandium.util.SecretUtil;
 import org.eclipse.californium.unixhealth.NetSocketHealthLogger;
 import org.eclipse.californium.unixhealth.NetStatLogger;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import picocli.CommandLine;
 import picocli.CommandLine.ArgGroup;
@@ -117,6 +119,11 @@ import picocli.CommandLine.ParseResult;
  */
 @SuppressWarnings("deprecation")
 public class PlugtestServer extends AbstractTestServer {
+
+	/**
+	 * @since 3.10
+	 */
+	private static final Logger LOGGER = LoggerFactory.getLogger(CoapServer.class);
 
 	static {
 		CoapConfig.register();

--- a/element-connector-tcp-netty/src/main/java/org/eclipse/californium/elements/tcp/netty/TcpClientConnector.java
+++ b/element-connector-tcp-netty/src/main/java/org/eclipse/californium/elements/tcp/netty/TcpClientConnector.java
@@ -90,6 +90,12 @@ public class TcpClientConnector implements Connector {
 		TCP_THREAD_GROUP.setDaemon(false);
 	}
 
+	/**
+	 * The logger.
+	 * 
+	 * @deprecated scope will change to private.
+	 */
+	@Deprecated
 	protected final Logger LOGGER = LoggerFactory.getLogger(getClass());
 
 	private final int numberOfThreads;

--- a/element-connector-tcp-netty/src/main/java/org/eclipse/californium/elements/tcp/netty/TcpServerConnector.java
+++ b/element-connector-tcp-netty/src/main/java/org/eclipse/californium/elements/tcp/netty/TcpServerConnector.java
@@ -77,6 +77,12 @@ public class TcpServerConnector implements Connector {
 		TCP_THREAD_GROUP.setDaemon(false);
 	}
 
+	/**
+	 * The logger.
+	 * 
+	 * @deprecated scope will change to private.
+	 */
+	@Deprecated
 	protected final Logger LOGGER = LoggerFactory.getLogger(getClass());
 
 	private final int numberOfThreads;

--- a/element-connector-tcp-netty/src/main/java/org/eclipse/californium/elements/tcp/netty/TlsClientConnector.java
+++ b/element-connector-tcp-netty/src/main/java/org/eclipse/californium/elements/tcp/netty/TlsClientConnector.java
@@ -46,6 +46,8 @@ import org.eclipse.californium.elements.config.Configuration;
 import org.eclipse.californium.elements.config.TcpConfig;
 import org.eclipse.californium.elements.util.CertPathUtil;
 import org.eclipse.californium.elements.util.StringUtil;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import io.netty.channel.Channel;
 import io.netty.handler.ssl.SslHandler;
@@ -56,6 +58,11 @@ import io.netty.util.concurrent.GenericFutureListener;
  * A TLS client connector that establishes outbound TLS connections.
  */
 public class TlsClientConnector extends TcpClientConnector {
+
+	/**
+	 * @since 3.10
+	 */
+	private static final Logger LOG = LoggerFactory.getLogger(TlsClientConnector.class);
 
 	/**
 	 * Context to be used to for connections.
@@ -176,11 +183,11 @@ public class TlsClientConnector extends TcpClientConnector {
 	 */
 	private SSLEngine createSllEngine(SocketAddress remoteAddress) {
 		if (remoteAddress instanceof InetSocketAddress) {
-			LOGGER.info("Connection to inet {}", StringUtil.toLog(remoteAddress));
+			LOG.info("Connection to inet {}", StringUtil.toLog(remoteAddress));
 			InetSocketAddress remote = (InetSocketAddress) remoteAddress;
 			return sslContext.createSSLEngine(remote.getAddress().getHostAddress(), remote.getPort());
 		} else {
-			LOGGER.info("Connection to {}", StringUtil.toLog(remoteAddress));
+			LOG.info("Connection to {}", StringUtil.toLog(remoteAddress));
 			return sslContext.createSSLEngine();
 		}
 	}
@@ -226,14 +233,14 @@ public class TlsClientConnector extends TcpClientConnector {
 		if (hostname != null) {
 			if (!CertPathUtil.matchDestination(certificate, hostname)) {
 				String cn = CertPathUtil.getSubjectsCn(certificate);
-				LOGGER.debug("Certificate {} validation failed: destination doesn't match", cn);
+				LOG.debug("Certificate {} validation failed: destination doesn't match", cn);
 				throw new SSLPeerUnverifiedException(
 						"Certificate " + cn + ": Destination '" + hostname + "' doesn't match!");
 			}
 		} else {
 			if (!CertPathUtil.matchLiteralIP(certificate, literalIp)) {
 				String cn = CertPathUtil.getSubjectsCn(certificate);
-				LOGGER.debug("Certificate {} validation failed: literal IP doesn't match", cn);
+				LOG.debug("Certificate {} validation failed: literal IP doesn't match", cn);
 				throw new SSLPeerUnverifiedException(
 						"Certificate " + cn + ": Literal IP " + literalIp + " doesn't match!");
 			}

--- a/element-connector-tcp-netty/src/main/java/org/eclipse/californium/elements/tcp/netty/TlsServerConnector.java
+++ b/element-connector-tcp-netty/src/main/java/org/eclipse/californium/elements/tcp/netty/TlsServerConnector.java
@@ -32,6 +32,8 @@ import org.eclipse.californium.elements.config.CertificateAuthenticationMode;
 import org.eclipse.californium.elements.config.Configuration;
 import org.eclipse.californium.elements.config.TcpConfig;
 import org.eclipse.californium.elements.util.StringUtil;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import io.netty.channel.Channel;
 import io.netty.handler.ssl.SslHandler;
@@ -40,6 +42,10 @@ import io.netty.handler.ssl.SslHandler;
  * A TLS server connector that accepts inbound TLS connections.
  */
 public class TlsServerConnector extends TcpServerConnector {
+	/**
+	 * @since 3.10
+	 */
+	private static final Logger LOG = LoggerFactory.getLogger(TlsServerConnector.class);
 
 	/**
 	 * Client authentication mode.
@@ -115,11 +121,11 @@ public class TlsServerConnector extends TcpServerConnector {
 	private SSLEngine createSllEngineForChannel(Channel ch) {
 		SocketAddress remoteAddress = ch.remoteAddress();
 		if (remoteAddress instanceof InetSocketAddress) {
-			LOGGER.info("Connection from inet {}", StringUtil.toLog(remoteAddress));
+			LOG.info("Connection from inet {}", StringUtil.toLog(remoteAddress));
 			InetSocketAddress remote = (InetSocketAddress) remoteAddress;
 			return sslContext.createSSLEngine(remote.getAddress().getHostAddress(), remote.getPort());
 		} else {
-			LOGGER.info("Connection from {}", StringUtil.toLog(remoteAddress));
+			LOG.info("Connection from {}", StringUtil.toLog(remoteAddress));
 			return sslContext.createSSLEngine();
 		}
 	}

--- a/element-connector/src/main/java/org/eclipse/californium/elements/EndpointContextUtil.java
+++ b/element-connector/src/main/java/org/eclipse/californium/elements/EndpointContextUtil.java
@@ -30,7 +30,7 @@ public class EndpointContextUtil {
 
 	private static final Logger LOGGER = LoggerFactory.getLogger(EndpointContextUtil.class);
 
-	private static final FilteredLogger WARN_FILTER = new FilteredLogger(LOGGER, 3, TimeUnit.SECONDS.toNanos(10));
+	private static final FilteredLogger WARN_FILTER = new FilteredLogger(LOGGER.getName(), 3, TimeUnit.SECONDS.toNanos(10));
 
 	/**
 	 * Match endpoint contexts based on a set of definitions.

--- a/element-connector/src/main/java/org/eclipse/californium/elements/UDPConnector.java
+++ b/element-connector/src/main/java/org/eclipse/californium/elements/UDPConnector.java
@@ -85,7 +85,12 @@ import org.slf4j.LoggerFactory;
  * {@link UdpConfig#UDP_SEND_BUFFER_SIZE} in the provided {@link Configuration}.
  */
 public class UDPConnector implements Connector {
-
+	/**
+	 * The logger.
+	 * 
+	 * @deprecated scope will change to private.
+	 */
+	@Deprecated
 	public static final Logger LOGGER = LoggerFactory.getLogger(UDPConnector.class);
 
 	static final ThreadGroup ELEMENTS_THREAD_GROUP = new ThreadGroup("Californium/Elements"); //$NON-NLS-1$

--- a/element-connector/src/main/java/org/eclipse/californium/elements/UdpMulticastConnector.java
+++ b/element-connector/src/main/java/org/eclipse/californium/elements/UdpMulticastConnector.java
@@ -109,7 +109,12 @@ import org.slf4j.LoggerFactory;
  *        one multicast group is provided.
  */
 public class UdpMulticastConnector extends UDPConnector {
-
+	/**
+	 * The logger.
+	 * 
+	 * @deprecated scope will change to private.
+	 */
+	@Deprecated
 	public static final Logger LOGGER = LoggerFactory.getLogger(UdpMulticastConnector.class);
 
 	/**

--- a/element-connector/src/main/java/org/eclipse/californium/elements/config/DocumentedDefinition.java
+++ b/element-connector/src/main/java/org/eclipse/californium/elements/config/DocumentedDefinition.java
@@ -26,7 +26,12 @@ import org.slf4j.LoggerFactory;
  * @since 3.0
  */
 public abstract class DocumentedDefinition<T> extends Definition<T> {
-
+	/**
+	 * The logger.
+	 * 
+	 * @deprecated to be removed.
+	 */
+	@Deprecated
 	protected static final Logger LOGGER = LoggerFactory.getLogger(DocumentedDefinition.class);
 
 	/**

--- a/element-connector/src/main/java/org/eclipse/californium/elements/util/FilteredLogger.java
+++ b/element-connector/src/main/java/org/eclipse/californium/elements/util/FilteredLogger.java
@@ -19,6 +19,7 @@ import java.util.Arrays;
 import java.util.concurrent.TimeUnit;
 
 import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.slf4j.event.Level;
 
 /**
@@ -63,7 +64,9 @@ public class FilteredLogger {
 	 * @param logger logger to log
 	 * @param maxPerPeriod maximum logging messages per period.
 	 * @param nanosPerPeriod nanoseconds per period.
+	 * @deprecated use {@link #FilteredLogger(String, long, long)} instead.
 	 */
+	@Deprecated
 	public FilteredLogger(Logger logger, long maxPerPeriod, long nanosPerPeriod) {
 		this(logger, maxPerPeriod, nanosPerPeriod, TimeUnit.NANOSECONDS);
 	}
@@ -76,9 +79,40 @@ public class FilteredLogger {
 	 * @param period period in units
 	 * @param unit time unit of the period
 	 * @since 3.5
+	 * @deprecated use {@link #FilteredLogger(String, long, long, TimeUnit)}
+	 *             instead.
 	 */
+	@Deprecated
 	public FilteredLogger(Logger logger, long maxPerPeriod, long period, TimeUnit unit) {
 		this.logger = logger;
+		this.maxPerPeriod = maxPerPeriod;
+		this.nanosPerPeriod = unit.toNanos(period);
+		this.startNanos = ClockUtil.nanoRealtime();
+	}
+
+	/**
+	 * Create logging filter.
+	 * 
+	 * @param name name of logger to log
+	 * @param maxPerPeriod maximum logging messages per period.
+	 * @param nanosPerPeriod nanoseconds per period.
+	 * @since 3.10
+	 */
+	public FilteredLogger(String name, long maxPerPeriod, long nanosPerPeriod) {
+		this(name, maxPerPeriod, nanosPerPeriod, TimeUnit.NANOSECONDS);
+	}
+
+	/**
+	 * Create logging filter.
+	 * 
+	 * @param name name of logger to log
+	 * @param maxPerPeriod maximum logging messages per period.
+	 * @param period period in units
+	 * @param unit time unit of the period
+	 * @since 3.10
+	 */
+	public FilteredLogger(String name, long maxPerPeriod, long period, TimeUnit unit) {
+		this.logger = LoggerFactory.getLogger(name);
 		this.maxPerPeriod = maxPerPeriod;
 		this.nanosPerPeriod = unit.toNanos(period);
 		this.startNanos = ClockUtil.nanoRealtime();

--- a/element-connector/src/main/java/org/eclipse/californium/elements/util/PemReader.java
+++ b/element-connector/src/main/java/org/eclipse/californium/elements/util/PemReader.java
@@ -26,6 +26,12 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 public class PemReader {
+	/**
+	 * The logger.
+	 * 
+	 * @deprecated scope will change to private.
+	 */
+	@Deprecated
 	public static final Logger LOGGER = LoggerFactory.getLogger(PemReader.class);
 
 	private static final Pattern BEGIN_PATTERN = Pattern.compile("^\\-+BEGIN\\s+([\\w\\s]+)\\-+$");

--- a/element-connector/src/main/java/org/eclipse/californium/elements/util/SslContextUtil.java
+++ b/element-connector/src/main/java/org/eclipse/californium/elements/util/SslContextUtil.java
@@ -140,6 +140,12 @@ import org.slf4j.LoggerFactory;
  */
 public class SslContextUtil {
 
+	/**
+	 * The logger.
+	 * 
+	 * @deprecated scope will change to private.
+	 */
+	@Deprecated
 	public static final Logger LOGGER = LoggerFactory.getLogger(SslContextUtil.class);
 
 	/**

--- a/scandium-core/src/main/java/org/eclipse/californium/scandium/DTLSConnector.java
+++ b/scandium-core/src/main/java/org/eclipse/californium/scandium/DTLSConnector.java
@@ -266,9 +266,9 @@ public class DTLSConnector implements Connector, PersistentConnector, Persistent
 
 	private static final Logger LOGGER = LoggerFactory.getLogger(DTLSConnector.class);
 	private static final Logger DROP_LOGGER = LoggerFactory.getLogger(LOGGER.getName() + ".drops");
-	private static final FilteredLogger DROP_LOGGER_IN_FILTERED = new FilteredLogger(DROP_LOGGER, 3, 30, TimeUnit.SECONDS);
-	private static final FilteredLogger DROP_LOGGER_OUT_FILTERED = new FilteredLogger(DROP_LOGGER, 3, 30, TimeUnit.SECONDS);
-	private static final FilteredLogger DROP_LOGGER_HANDSHAKE_RESULTS_FILTERED = new FilteredLogger(DROP_LOGGER, 3, 30, TimeUnit.SECONDS);
+	private static final FilteredLogger DROP_LOGGER_IN_FILTERED = new FilteredLogger(DROP_LOGGER.getName(), 3, 30, TimeUnit.SECONDS);
+	private static final FilteredLogger DROP_LOGGER_OUT_FILTERED = new FilteredLogger(DROP_LOGGER.getName(), 3, 30, TimeUnit.SECONDS);
+	private static final FilteredLogger DROP_LOGGER_HANDSHAKE_RESULTS_FILTERED = new FilteredLogger(DROP_LOGGER.getName(), 3, 30, TimeUnit.SECONDS);
 	private static final int MAX_CIPHERTEXT_EXPANSION = CipherSuite.getOverallMaxCiphertextExpansion();
 	private static final int MAX_DATAGRAM_BUFFER_SIZE = Record.DTLS_MAX_PLAINTEXT_FRAGMENT_LENGTH
 			+ Record.DTLS_HANDSHAKE_HEADER_LENGTH + MAX_CIPHERTEXT_EXPANSION;

--- a/scandium-core/src/main/java/org/eclipse/californium/scandium/DtlsClusterConnector.java
+++ b/scandium-core/src/main/java/org/eclipse/californium/scandium/DtlsClusterConnector.java
@@ -70,7 +70,7 @@ public class DtlsClusterConnector extends DTLSConnector {
 
 	private static final Logger LOGGER = LoggerFactory.getLogger(DtlsClusterConnector.class);
 
-	private final FilteredLogger FILTER = new FilteredLogger(LOGGER, 3, TimeUnit.SECONDS.toNanos(10));
+	private final FilteredLogger FILTER = new FilteredLogger(LOGGER.getName(), 3, TimeUnit.SECONDS.toNanos(10));
 
 	/**
 	 * Offset of cluster record type.

--- a/scandium-core/src/main/java/org/eclipse/californium/scandium/dtls/ClientHandshaker.java
+++ b/scandium-core/src/main/java/org/eclipse/californium/scandium/dtls/ClientHandshaker.java
@@ -72,6 +72,8 @@ import org.eclipse.californium.scandium.dtls.cipher.XECDHECryptography;
 import org.eclipse.californium.scandium.dtls.cipher.XECDHECryptography.SupportedGroup;
 import org.eclipse.californium.scandium.util.SecretUtil;
 import org.eclipse.californium.scandium.util.ServerNames;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * ClientHandshaker does the protocol handshaking from the point of view of a
@@ -136,6 +138,11 @@ import org.eclipse.californium.scandium.util.ServerNames;
  */
 @NoPublicAPI
 public class ClientHandshaker extends Handshaker {
+
+	/**
+	 * @since 3.10
+	 */
+	private final Logger LOGGER = LoggerFactory.getLogger(getClass());
 
 	protected static final HandshakeState[] INIT = {
 			new HandshakeState(HandshakeType.HELLO_VERIFY_REQUEST, true),

--- a/scandium-core/src/main/java/org/eclipse/californium/scandium/dtls/Handshaker.java
+++ b/scandium-core/src/main/java/org/eclipse/californium/scandium/dtls/Handshaker.java
@@ -127,6 +127,12 @@ import org.slf4j.LoggerFactory;
  */
 public abstract class Handshaker implements Destroyable {
 
+	/**
+	 * The logger.
+	 * 
+	 * @deprecated scope will change to private.
+	 */
+	@Deprecated
 	protected final Logger LOGGER = LoggerFactory.getLogger(getClass());
 
 	protected Random clientRandom;

--- a/scandium-core/src/main/java/org/eclipse/californium/scandium/dtls/HelloExtension.java
+++ b/scandium-core/src/main/java/org/eclipse/californium/scandium/dtls/HelloExtension.java
@@ -51,7 +51,12 @@ import org.slf4j.LoggerFactory;
  * </pre>
  */
 public abstract class HelloExtension {
-
+	/**
+	 * The logger.
+	 * 
+	 * @deprecated to be removed.
+	 */
+	@Deprecated
 	protected static final Logger LOGGER = LoggerFactory.getLogger(HelloExtension.class);
 
 	public static final int TYPE_BITS = 16;

--- a/scandium-core/src/main/java/org/eclipse/californium/scandium/dtls/InMemoryConnectionStore.java
+++ b/scandium-core/src/main/java/org/eclipse/californium/scandium/dtls/InMemoryConnectionStore.java
@@ -105,7 +105,7 @@ import org.slf4j.LoggerFactory;
 public class InMemoryConnectionStore implements ResumptionSupportingConnectionStore {
 
 	private static final Logger LOGGER = LoggerFactory.getLogger(InMemoryConnectionStore.class);
-	private static final FilteredLogger WARN_FILTER = new FilteredLogger(LOGGER, 3, TimeUnit.SECONDS.toNanos(10));
+	private static final FilteredLogger WARN_FILTER = new FilteredLogger(LOGGER.getName(), 3, TimeUnit.SECONDS.toNanos(10));
 
 	// extra cid bytes additionally to required bytes for small capacity.
 	private static final int DEFAULT_SMALL_EXTRA_CID_LENGTH = 2;

--- a/scandium-core/src/main/java/org/eclipse/californium/scandium/dtls/InMemoryReadWriteLockConnectionStore.java
+++ b/scandium-core/src/main/java/org/eclipse/californium/scandium/dtls/InMemoryReadWriteLockConnectionStore.java
@@ -93,7 +93,7 @@ import org.slf4j.LoggerFactory;
 public class InMemoryReadWriteLockConnectionStore implements ReadWriteLockConnectionStore {
 
 	private static final Logger LOGGER = LoggerFactory.getLogger(InMemoryReadWriteLockConnectionStore.class);
-	private static final FilteredLogger WARN_FILTER = new FilteredLogger(LOGGER, 3, TimeUnit.SECONDS.toNanos(10));
+	private static final FilteredLogger WARN_FILTER = new FilteredLogger(LOGGER.getName(), 3, TimeUnit.SECONDS.toNanos(10));
 
 	// extra cid bytes additionally to required bytes for small capacity.
 	private static final int DEFAULT_SMALL_EXTRA_CID_LENGTH = 2;

--- a/scandium-core/src/main/java/org/eclipse/californium/scandium/dtls/ResumingClientHandshaker.java
+++ b/scandium-core/src/main/java/org/eclipse/californium/scandium/dtls/ResumingClientHandshaker.java
@@ -46,6 +46,8 @@ import org.eclipse.californium.scandium.dtls.AlertMessage.AlertDescription;
 import org.eclipse.californium.scandium.dtls.AlertMessage.AlertLevel;
 import org.eclipse.californium.scandium.dtls.cipher.CipherSuite;
 import org.eclipse.californium.scandium.util.SecretUtil;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * The resuming client handshaker executes a abbreviated handshake by adding a
@@ -106,6 +108,8 @@ import org.eclipse.californium.scandium.util.SecretUtil;
  */
 @NoPublicAPI
 public class ResumingClientHandshaker extends ClientHandshaker {
+
+	private static final Logger LOGGER = LoggerFactory.getLogger(ResumingClientHandshaker.class);
 
 	private static final HandshakeState[] ABBREVIATED_HANDSHAKE = { 
 			new HandshakeState(ContentType.CHANGE_CIPHER_SPEC),

--- a/scandium-core/src/main/java/org/eclipse/californium/scandium/dtls/ServerHandshaker.java
+++ b/scandium-core/src/main/java/org/eclipse/californium/scandium/dtls/ServerHandshaker.java
@@ -125,6 +125,8 @@ import org.slf4j.LoggerFactory;
 @NoPublicAPI
 public class ServerHandshaker extends Handshaker {
 
+	private final Logger LOGGER = LoggerFactory.getLogger(getClass());
+
 	private static final HandshakeState[] CLIENT_HELLO = { new HandshakeState(HandshakeType.CLIENT_HELLO) };
 
 	private static final HandshakeState[] CLIENT_CERTIFICATE = { new HandshakeState(HandshakeType.CERTIFICATE),

--- a/scandium-core/src/main/java/org/eclipse/californium/scandium/dtls/cipher/DefaultCipherSuiteSelector.java
+++ b/scandium-core/src/main/java/org/eclipse/californium/scandium/dtls/cipher/DefaultCipherSuiteSelector.java
@@ -38,7 +38,12 @@ import org.slf4j.LoggerFactory;
 public class DefaultCipherSuiteSelector implements CipherSuiteSelector {
 
 	// Logging ////////////////////////////////////////////////////////
-
+	/**
+	 * The logger.
+	 * 
+	 * @deprecated to be removed.
+	 */
+	@Deprecated
 	protected static final Logger LOGGER = LoggerFactory.getLogger(DefaultCipherSuiteSelector.class);
 
 	@Override

--- a/scandium-core/src/main/java/org/eclipse/californium/scandium/dtls/cipher/XECDHECryptography.java
+++ b/scandium-core/src/main/java/org/eclipse/californium/scandium/dtls/cipher/XECDHECryptography.java
@@ -113,7 +113,12 @@ import javax.security.auth.Destroyable;
 public final class XECDHECryptography implements Destroyable {
 
 	// Logging ////////////////////////////////////////////////////////
-
+	/**
+	 * The logger.
+	 * 
+	 * @deprecated scope will change to private.
+	 */
+	@Deprecated
 	protected static final Logger LOGGER = LoggerFactory.getLogger(XECDHECryptography.class);
 
 	// Static members /////////////////////////////////////////////////

--- a/scandium-core/src/main/java/org/eclipse/californium/scandium/dtls/x509/AsyncNewAdvancedCertificateVerifier.java
+++ b/scandium-core/src/main/java/org/eclipse/californium/scandium/dtls/x509/AsyncNewAdvancedCertificateVerifier.java
@@ -33,6 +33,8 @@ import org.eclipse.californium.scandium.dtls.CertificateVerificationResult;
 import org.eclipse.californium.scandium.dtls.ConnectionId;
 import org.eclipse.californium.scandium.dtls.HandshakeResultHandler;
 import org.eclipse.californium.scandium.util.ServerNames;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * Simple asynchronous test implementation of
@@ -45,6 +47,10 @@ import org.eclipse.californium.scandium.util.ServerNames;
  * @since 2.5
  */
 public class AsyncNewAdvancedCertificateVerifier extends StaticNewAdvancedCertificateVerifier {
+	/**
+	 * @since 3.10
+	 */
+	private static final Logger LOG = LoggerFactory.getLogger(AsyncNewAdvancedCertificateVerifier.class);
 
 	/**
 	 * Thread factory.
@@ -84,11 +90,11 @@ public class AsyncNewAdvancedCertificateVerifier extends StaticNewAdvancedCertif
 	public AsyncNewAdvancedCertificateVerifier setDelay(int delayMillis) {
 		this.delayMillis = delayMillis;
 		if (delayMillis > 0) {
-			LOGGER.info("Asynchronous delayed certificate verifier {}ms.", delayMillis);
+			LOG.info("Asynchronous delayed certificate verifier {}ms.", delayMillis);
 		} else if (delayMillis < 0) {
-			LOGGER.info("Synchronous delayed certificate verifier {}ms.", -delayMillis);
+			LOG.info("Synchronous delayed certificate verifier {}ms.", -delayMillis);
 		} else {
-			LOGGER.info("Synchronous certificate verifier.");
+			LOG.info("Synchronous certificate verifier.");
 		}
 		return this;
 	}
@@ -145,11 +151,11 @@ public class AsyncNewAdvancedCertificateVerifier extends StaticNewAdvancedCertif
 		CertPath certPath = result.getCertificatePath();
 		PublicKey publicKey = result.getPublicKey();
 		if (certPath == null && publicKey == null) {
-			LOGGER.info("Validation failed!");
+			LOG.info("Validation failed!");
 		} else if (certPath != null) {
-			LOGGER.info("Validation {}", certPath.getCertificates().size());
+			LOG.info("Validation {}", certPath.getCertificates().size());
 		} else if (publicKey != null) {
-			LOGGER.info("Validation RPK");
+			LOG.info("Validation RPK");
 		}
 		resultHandler.apply(result);
 	}

--- a/scandium-core/src/main/java/org/eclipse/californium/scandium/dtls/x509/StaticNewAdvancedCertificateVerifier.java
+++ b/scandium-core/src/main/java/org/eclipse/californium/scandium/dtls/x509/StaticNewAdvancedCertificateVerifier.java
@@ -63,6 +63,12 @@ public class StaticNewAdvancedCertificateVerifier implements NewAdvancedCertific
 	private static final X509Certificate[] X509_TRUST_ALL = new X509Certificate[0];
 	private static final RawPublicKeyIdentity[] RPK_TRUST_ALL = new RawPublicKeyIdentity[0];
 
+	/**
+	 * The logger.
+	 * 
+	 * @deprecated scope will change to private.
+	 */
+	@Deprecated
 	protected final Logger LOGGER = LoggerFactory.getLogger(getClass());
 
 	/**


### PR DESCRIPTION
Redesign FilteredLogger to use names instead of exposing logger.