### PR TITLE
Fix tinydtls interop test.

### DIFF
--- a/californium-tests/californium-interoperability-tests/README.md
+++ b/californium-tests/californium-interoperability-tests/README.md
@@ -18,7 +18,7 @@ For [openssl](https://github.com/openssl/openssl) some notes are in [OpenSslProc
 
 For [Mbed-TLS](https://github.com/Mbed-TLS/mbedtls) some notes are in [MbedTlsProcessUtil](src/test/java/org/eclipse/californium/interoperability/test/mbedtls/MbedTlsProcessUtil.java#L39-L58)
 
-For [tinydtls](https://github.com/eclipse/tinydtls) some notes are in [TinydtlsProcessUtil](src/test/java/org/eclipse/californium/interoperability/test/tinydtls/TinydtlsProcessUtil.java#L28-L38)
+For [tinydtls](https://github.com/eclipse/tinydtls) some notes are in [TinydtlsProcessUtil](src/test/java/org/eclipse/californium/interoperability/test/tinydtls/TinydtlsProcessUtil.java#L28-L38). Ensure to use the ""feature/connection_id" to enable DTLS 1.2 CID support.
 
 When the binaries a build and install in the "PATH", the tests are execute using
 
@@ -62,3 +62,6 @@ mvn test -Dorg.eclipse.californium.elements.runner.TestRepeater.repeats=1000
 
 enables to select an other number, here 1000.
 
+# Testing Interoperability Of Specific Versions
+
+Just in the case someone needs to test with specific versions of the other implementations, that may work "out of the box" or not. Some of the libraries have bugs in single features on single versions so a failure requires then analysis and the knowledge to do so. Sometimes the CLI-API is changing, so also be careful with that.

--- a/californium-tests/californium-interoperability-tests/src/test/java/org/eclipse/californium/interoperability/test/tinydtls/TinydtlsClientInteroperabilityTest.java
+++ b/californium-tests/californium-interoperability-tests/src/test/java/org/eclipse/californium/interoperability/test/tinydtls/TinydtlsClientInteroperabilityTest.java
@@ -17,6 +17,7 @@ import static org.eclipse.californium.interoperability.test.ConnectorUtil.HANDSH
 import static org.eclipse.californium.interoperability.test.ProcessUtil.TIMEOUT_MILLIS;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
 
 import java.io.IOException;
@@ -118,7 +119,7 @@ public class TinydtlsClientInteroperabilityTest {
 
 	@Test
 	public void testTinydtlsClientCid() throws Exception {
-		processUtil.setTag("tinydtls-client, " + cipherSuite.name());
+		processUtil.setTag("tinydtls-client, cid, " + cipherSuite.name());
 		processUtil.addExtraArgs("-z", "-e", "-r");
 		scandiumUtil.start(BIND, null, cipherSuite);
 
@@ -138,8 +139,9 @@ public class TinydtlsClientInteroperabilityTest {
 		processUtil.send("client:exit\n");
 
 		EndpointContext context = scandiumUtil.getContext(TIMEOUT_MILLIS);
-		Bytes bytes = context.get(DtlsEndpointContext.KEY_WRITE_CONNECTION_ID);
+		Bytes bytes = context.get(DtlsEndpointContext.KEY_READ_CONNECTION_ID);
 		assertNotNull("Missing CID", bytes);
+		assertFalse("Empyt CID", bytes.isEmpty());
 		Boolean extendedMasterSecret = context.get(DtlsEndpointContext.KEY_EXTENDED_MASTER_SECRET);
 		assertEquals("Missing extended master secret", Boolean.TRUE, extendedMasterSecret);
 

--- a/californium-tests/californium-interoperability-tests/src/test/java/org/eclipse/californium/interoperability/test/tinydtls/TinydtlsProcessUtil.java
+++ b/californium-tests/californium-interoperability-tests/src/test/java/org/eclipse/californium/interoperability/test/tinydtls/TinydtlsProcessUtil.java
@@ -34,6 +34,9 @@ import org.eclipse.californium.scandium.dtls.cipher.CipherSuite;
  * the names "tinydtls-client" and "tinydtls-server" for the binaries found in
  * {@code <tinydtls>}/tests when copy or link them into your {@code PATH}.
  * 
+ * In order to support DTLS 1.2 CID it's required to use the
+ * "feature/connection_id" branch.
+ * 
  * @since 3.8
  */
 public class TinydtlsProcessUtil extends ProcessUtil {
@@ -103,9 +106,9 @@ public class TinydtlsProcessUtil extends ProcessUtil {
 			CipherSuite cipherSuite) throws IOException, InterruptedException {
 		List<String> args = new ArrayList<String>();
 		String tinydtlsCiphers = TinydtlsUtil.getTinydtlsCipherSuites(cipherSuite);
-		args.addAll(Arrays.asList(CLIENT, "-v", verboseLevel, "-c", tinydtlsCiphers, destination,
-				Integer.toString(port)));
+		args.addAll(Arrays.asList(CLIENT, "-v", verboseLevel, "-c", tinydtlsCiphers));
 		args.addAll(extraArgs);
+		args.addAll(Arrays.asList(destination, Integer.toString(port)));
 		print(args);
 		execute(args);
 		return tinydtlsCiphers;


### PR DESCRIPTION
Check for read CID instead of write CID.
Move extra arguments before destination.