### PR TITLE
Add Exchange as a parameter to the ObserveResource::getNotificationSequenceNumber

### DIFF
--- a/californium-core/api-changes.json
+++ b/californium-core/api-changes.json
@@ -109,7 +109,7 @@
 			}
 		}
 	],
-	"3.10.0": [
+	"3.11.0": [
 		{
 			"extension": "revapi.differences",
 			"configuration": {
@@ -118,13 +118,13 @@
 					{
 						"code": "java.method.numberOfParametersChanged",
 						"old": "method int org.eclipse.californium.core.server.resources.ObservableResource::getNotificationSequenceNumber()",
-						"new": "method int org.eclipse.californium.core.server.resources.ObservableResource::getNotificationSequenceNumber(===org.eclipse.californium.core.network.Exchange===)",
+						"new": "method int org.eclipse.californium.core.server.resources.ObservableResource::getNotificationSequenceNumber(org.eclipse.californium.core.network.Exchange)",
 						"justification": "Redesign to support separate sequence numbers for different observe tokens"
 					},
 					{
 						"code": "java.method.numberOfParametersChanged",
 						"old": "method int org.eclipse.californium.core.CoapResource::getNotificationSequenceNumber()",
-						"new": "method int org.eclipse.californium.core.CoapResource::getNotificationSequenceNumber(===org.eclipse.californium.core.network.Exchange===)",
+						"new": "method int org.eclipse.californium.core.CoapResource::getNotificationSequenceNumber(org.eclipse.californium.core.network.Exchange)",
 						"justification": "Redesign to support separate sequence numbers for different observe tokens"
 					}
 				]

--- a/californium-core/api-changes.json
+++ b/californium-core/api-changes.json
@@ -108,6 +108,27 @@
 				]
 			}
 		}
+	],
+	"3.10.0": [
+		{
+			"extension": "revapi.differences",
+			"configuration": {
+				"ignore": true,
+				"differences": [
+					{
+						"code": "java.method.numberOfParametersChanged",
+						"old": "method int org.eclipse.californium.core.server.resources.ObservableResource::getNotificationSequenceNumber()",
+						"new": "method int org.eclipse.californium.core.server.resources.ObservableResource::getNotificationSequenceNumber(===org.eclipse.californium.core.network.Exchange===)",
+						"justification": "Redesign to support separate sequence numbers for different observe tokens"
+					},
+					{
+						"code": "java.method.numberOfParametersChanged",
+						"old": "method int org.eclipse.californium.core.CoapResource::getNotificationSequenceNumber()",
+						"new": "method int org.eclipse.californium.core.CoapResource::getNotificationSequenceNumber(===org.eclipse.californium.core.network.Exchange===)",
+						"justification": "Redesign to support separate sequence numbers for different observe tokens"
+					}
+				]
+			}
+		}
 	]
-	
 }

--- a/californium-core/src/main/java/org/eclipse/californium/core/CoapResource.java
+++ b/californium-core/src/main/java/org/eclipse/californium/core/CoapResource.java
@@ -376,7 +376,7 @@ public class CoapResource implements Resource, ObservableResource {
 	}
 
 	@Override
-	public int getNotificationSequenceNumber() {
+	public int getNotificationSequenceNumber(Exchange exchange) {
 		return notificationOrderer.getCurrent();
 	}
 

--- a/californium-core/src/main/java/org/eclipse/californium/core/observe/ObserveRelation.java
+++ b/californium-core/src/main/java/org/eclipse/californium/core/observe/ObserveRelation.java
@@ -403,7 +403,7 @@ public class ObserveRelation {
 	 * The first response will {@link #setEstablished()} the relation and
 	 * {@link ObservableResource#addObserveRelation(ObserveRelation)} it. If not
 	 * {@link #isCanceled()}, and the response {@link Response#isSuccess()},
-	 * {@link ObservableResource#getNotificationSequenceNumber()} will be set.
+	 * {@link ObservableResource#getNotificationSequenceNumber(Exchange)} will be set.
 	 * 
 	 * @param response response
 	 * @return current relation state.
@@ -416,7 +416,7 @@ public class ObserveRelation {
 		} else if (isEstablished()) {
 			exchange.retransmitResponse();
 			if (response.isSuccess()) {
-				response.getOptions().setObserve(resource.getNotificationSequenceNumber());
+				response.getOptions().setObserve(resource.getNotificationSequenceNumber(exchange));
 			}
 			return State.ESTABILSHED;
 		} else {
@@ -427,7 +427,7 @@ public class ObserveRelation {
 				established = !isCanceled();
 			}
 			if (established) {
-				response.getOptions().setObserve(resource.getNotificationSequenceNumber());
+				response.getOptions().setObserve(resource.getNotificationSequenceNumber(exchange));
 				return State.INIT;
 			} else {
 				return State.CANCELED;
@@ -636,7 +636,7 @@ public class ObserveRelation {
 	 * 
 	 * The first response will {@link #setEstablished()} the relation and
 	 * {@link ObservableResource#addObserveRelation(ObserveRelation)}. And the
-	 * {@link ObservableResource#getNotificationSequenceNumber()} will be set to
+	 * {@link ObservableResource#getNotificationSequenceNumber(Exchange)} will be set to
 	 * the options of all responses.
 	 * 
 	 * @param relation the observe relation, or {@code null}, if not available

--- a/californium-core/src/main/java/org/eclipse/californium/core/server/resources/ObservableResource.java
+++ b/californium-core/src/main/java/org/eclipse/californium/core/server/resources/ObservableResource.java
@@ -45,8 +45,10 @@ public interface ObservableResource {
 	/**
 	 * Returns the current notification number.
 	 *
+	 * @param exchange the current exchange
 	 * @return the current notification number
 	 * @see ObserveNotificationOrderer#getCurrent()
+	 * @since 3.11 (add parameter exchange)
 	 */
 	int getNotificationSequenceNumber(Exchange exchange);
 

--- a/californium-core/src/main/java/org/eclipse/californium/core/server/resources/ObservableResource.java
+++ b/californium-core/src/main/java/org/eclipse/californium/core/server/resources/ObservableResource.java
@@ -16,6 +16,7 @@
 package org.eclipse.californium.core.server.resources;
 
 import org.eclipse.californium.core.coap.CoAP.Type;
+import org.eclipse.californium.core.network.Exchange;
 import org.eclipse.californium.core.observe.ObserveNotificationOrderer;
 import org.eclipse.californium.core.observe.ObserveRelation;
 
@@ -43,11 +44,11 @@ public interface ObservableResource {
 
 	/**
 	 * Returns the current notification number.
-	 * 
+	 *
 	 * @return the current notification number
 	 * @see ObserveNotificationOrderer#getCurrent()
 	 */
-	int getNotificationSequenceNumber();
+	int getNotificationSequenceNumber(Exchange exchange);
 
 	/**
 	 * Checks if this resource is observable by remote CoAP clients.

--- a/californium-core/src/test/java/org/eclipse/californium/core/observe/ObserveRelationTest.java
+++ b/californium-core/src/test/java/org/eclipse/californium/core/observe/ObserveRelationTest.java
@@ -221,7 +221,7 @@ public class ObserveRelationTest {
 		}
 
 		@Override
-		public int getNotificationSequenceNumber() {
+		public int getNotificationSequenceNumber(Exchange exchange) {
 			return 0;
 		}
 


### PR DESCRIPTION
In a multi-tenant environment (ThingsBoard), we use the same resource path (e.g.,/api/v1/device/attributes) that multiple devices use. Each observation from different devices has its own Token. We must make the server have separate Observe sequences - one per device. That is why we need to pass the Exchange as a parameter to extract the Token. This will allow us to overwrite the getNotificationSequenceNumber method in our custom Resource. 