### PR TITLE
Adapt destination for website.

### DIFF
--- a/jenkins/Jenkinsfile
+++ b/jenkins/Jenkinsfile
@@ -95,7 +95,7 @@ pipeline {
         container("hugo") {
           dir("${WEBSITE_SRC_DIR}") {
             sh '''#!/bin/bash
-              hugo -v -d "${WEBSITE_REPO_DIR}" -b "https://www.eclipse.org/${PROJECT_NAME}/"
+              hugo -v -d "${WEBSITE_REPO_DIR}" -b "https://eclipse.dev/${PROJECT_NAME}/"
             '''
           }
         }


### PR DESCRIPTION
Move from www.eclipse.org/californium to eclipse.dev/californium.