### PR TITLE
Coap-Http-Cross-Prox: don't fail on missing content type, if no payload

### DIFF
--- a/californium-proxy2/src/main/java/org/eclipse/californium/proxy2/http/ContentTypedEntity.java
+++ b/californium-proxy2/src/main/java/org/eclipse/californium/proxy2/http/ContentTypedEntity.java
@@ -41,21 +41,27 @@ public class ContentTypedEntity {
 	/**
 	 * Create instance from content type and payload.
 	 * 
-	 * @param contentType content type
-	 * @param payload payload.
+	 * @param contentType content type. May be {@code null}, if no payload is
+	 *            provided.
+	 * @param payload payload. For no payload provide {@code null} or an empty
+	 *            array.
+	 * @throws NullPointerException if contentType is null, but payload is
+	 *             provided.
+	 * @deprecated use {@link #create(ContentType, byte[])} instead.
 	 */
+	@Deprecated
 	public ContentTypedEntity(ContentType contentType, byte[] payload) {
-		if (contentType == null) {
-			throw new NullPointerException("content type must not be null!");
+		this.payload = payload != null && payload.length > 0 ? payload : null;
+		if (contentType == null && this.payload != null) {
+			throw new NullPointerException("content type must not be null, if payload is provided!");
 		}
 		this.contentType = contentType;
-		this.payload = payload != null && payload.length > 0 ? payload : null;
 	}
 
 	/**
 	 * Get content type.
 	 * 
-	 * @return content type
+	 * @return content type, or {@code null}, if not provided
 	 */
 	public ContentType getContentType() {
 		return contentType;
@@ -73,10 +79,14 @@ public class ContentTypedEntity {
 	/**
 	 * Create entity producer.
 	 * 
-	 * @return entity producer
+	 * @return entity producer, or {@code null}, if no content type is provided.
 	 */
 	public AsyncEntityProducer createProducer() {
-		return AsyncEntityProducers.create(payload, contentType);
+		if (contentType != null) {
+			return AsyncEntityProducers.create(payload, contentType);
+		} else {
+			return null;
+		}
 	}
 
 	/**
@@ -87,5 +97,25 @@ public class ContentTypedEntity {
 	 */
 	public static AsyncEntityProducer createProducer(ContentTypedEntity entity) {
 		return entity != null ? entity.createProducer() : null;
+	}
+
+	/**
+	 * Create instance from content type and payload.
+	 * 
+	 * @param contentType content type. May be {@code null}, if no payload is
+	 *            provided.
+	 * @param payload payload. For no payload provide {@code null} or an empty
+	 *            array.
+	 * @return entity, if content type is provided, {@code null}, otherwise.
+	 * @throws NullPointerException if contentType is null, but payload is
+	 *             provided.
+	 * @since 3.13
+	 */
+	public static ContentTypedEntity create(ContentType contentType, byte[] payload) {
+		ContentTypedEntity entity = new ContentTypedEntity(contentType, payload);
+		if (entity.getContentType() != null) {
+			return entity;
+		}
+		return null;
 	}
 }

--- a/californium-proxy2/src/main/java/org/eclipse/californium/proxy2/http/ContentTypedEntityConsumer.java
+++ b/californium-proxy2/src/main/java/org/eclipse/californium/proxy2/http/ContentTypedEntityConsumer.java
@@ -65,7 +65,7 @@ public class ContentTypedEntityConsumer extends AbstractBinAsyncEntityConsumer<C
 
 	@Override
 	protected ContentTypedEntity generateContent() throws IOException {
-		return new ContentTypedEntity(contentType, buffer.toByteArray());
+		return ContentTypedEntity.create(contentType, buffer.toByteArray());
 	}
 
 	@Override

--- a/californium-proxy2/src/main/java/org/eclipse/californium/proxy2/http/CrossProtocolTranslator.java
+++ b/californium-proxy2/src/main/java/org/eclipse/californium/proxy2/http/CrossProtocolTranslator.java
@@ -691,7 +691,7 @@ public class CrossProtocolTranslator {
 				}
 			}
 			// create the entity
-			httpEntity = new ContentTypedEntity(contentType, payload);
+			httpEntity = ContentTypedEntity.create(contentType, payload);
 		}
 
 		return httpEntity;

--- a/californium-proxy2/src/main/java/org/eclipse/californium/proxy2/http/Http2CoapTranslator.java
+++ b/californium-proxy2/src/main/java/org/eclipse/californium/proxy2/http/Http2CoapTranslator.java
@@ -337,7 +337,9 @@ public class Http2CoapTranslator {
 			if (httpEntity != null) {
 				// get the content-type from the entity and set the header
 				ContentType contentType = httpEntity.getContentType();
-				httpResponse.setHeader("content-type", contentType.toString());
+				if (contentType != null) {
+					httpResponse.setHeader("content-type", contentType.toString());
+				}
 			}
 		}
 		return new ProxyResponseProducer(httpResponse, ContentTypedEntity.createProducer(httpEntity));


### PR DESCRIPTION
is provided as well.

Fix issue #2252