### PR TITLE
OSCORE: Add support for additional AEAD algorithms

### DIFF
--- a/cf-oscore/src/main/java/org/eclipse/californium/cose/AlgorithmID.java
+++ b/cf-oscore/src/main/java/org/eclipse/californium/cose/AlgorithmID.java
@@ -84,6 +84,8 @@ public enum AlgorithmID {
     ECDH_SS_HKDF_256_AES_KW_128(-32, 0, 0),
     ECDH_SS_HKDF_256_AES_KW_192(-33, 0, 0),
     ECDH_SS_HKDF_256_AES_KW_256(-34, 0, 0),
+    
+    CHACHA20_POLY1305(24, 256, 128),
     ;
  
     private final CBORObject value;


### PR DESCRIPTION
Adds support for the following algorithms for use with OSCORE:
- AES_CCM_64_64_256
- AES_CCM_16_64_256
- AES_CCM_16_128_256
- AES_CCM_64_128_256
- AES_GCM_128
- AES_GCM_192
- AES_GCM_256
- CHACHA20_POLY1305