### PR TITLE
OSCORE: Fix incorrect CoAP method in plugtest client

### DIFF
--- a/demo-apps/cf-plugtest-client/src/main/java/org/eclipse/californium/plugtests/PlugtestClient.java
+++ b/demo-apps/cf-plugtest-client/src/main/java/org/eclipse/californium/plugtests/PlugtestClient.java
@@ -779,7 +779,7 @@ public class PlugtestClient {
 
 		System.out.println("===============\nOSCORE 04");
 		System.out.println("---------------\nPOST /oscore\n---------------");
-		r = Request.newPut();
+		r = Request.newPost();
 		r.setPayload("non-empty");
 		r.getOptions().setContentFormat(MediaTypeRegistry.TEXT_PLAIN);
 		r.getOptions().setOscore(Bytes.EMPTY);


### PR DESCRIPTION
Fixes a small issue where the incorrect CoAP method was used for one of the plugtests for OSCORE.