### PR TITLE
Fix potential memory leak in InMemoryReadWriteLockConnectionStore

### DIFF
--- a/scandium-core/src/main/java/org/eclipse/californium/scandium/dtls/InMemoryReadWriteLockConnectionStore.java
+++ b/scandium-core/src/main/java/org/eclipse/californium/scandium/dtls/InMemoryReadWriteLockConnectionStore.java
@@ -160,6 +160,7 @@ public class InMemoryReadWriteLockConnectionStore implements ReadWriteLockConnec
 							removeByAddressConnections(staleConnection);
 							removeByEstablishedSessions(staleConnection.getEstablishedSessionIdentifier(),
 									staleConnection);
+							removeByPrincipal(staleConnection.getEstablishedPeerIdentity(), staleConnection);
 							ConnectionListener listener = connectionListener;
 							if (listener != null) {
 								listener.onConnectionRemoved(staleConnection);


### PR DESCRIPTION
During our stress test, I noticed that memory usage kept going up and didn't decrease significantly after GC.

![f38a-4841-a4f1-7c6e0347faf8](https://github.com/user-attachments/assets/ca6bb8b7-1354-4d92-ab3c-4b9a694ba37f)

Then I checked the classes in memory. The `Connection` class in connectionsByPrincipal never seems to get cleaned up. Finally I found `removeByPrincipal` seems to be missed in `onEviction` of `EvictionListener`.