### PR TITLE
OSCORE: fix HMAC validation during context rederivation

### DIFF
--- a/cf-oscore/src/main/java/org/eclipse/californium/oscore/ContextRederivation.java
+++ b/cf-oscore/src/main/java/org/eclipse/californium/oscore/ContextRederivation.java
@@ -317,15 +317,16 @@ public class ContextRederivation {
 			// Generate HMAC output using S2
 			byte[] hmacOutput = performHMAC(ctx.getContextRederivationKey(), contextS2);
 
+			// Decode the received context ID from a CBOR byte string
+			byte[] contextIdParsed = decodeFromCborBstrBytes(contextID);
+
 			// Compare the HMAC output with the equivalent in the message
-			byte[] messageHmacOutput = Arrays.copyOfRange(ctx.getIdContext(), SEGMENT_LENGTH, SEGMENT_LENGTH * 2);
+			byte[] messageHmacOutput = Arrays.copyOfRange(contextIdParsed, SEGMENT_LENGTH, SEGMENT_LENGTH * 2);
 			if (Arrays.equals(hmacOutput, messageHmacOutput) == false) {
 				throw new OSException(ErrorDescriptions.CONTEXT_REGENERATION_FAILED);
 			}
 
-			// Generate a new context with the received Context ID, after
-			// decoded from a CBOR byte string
-			byte[] contextIdParsed = decodeFromCborBstrBytes(contextID);
+			// Generate a new context with the received Context ID
 			OSCoreCtx newCtx = rederiveWithContextID(ctx, contextIdParsed);
 
 			// Set the next phase of the re-derivation procedure


### PR DESCRIPTION
This is related to #2294 but does not directly address it. 

I found that the server was always accepting duplicate requests as valid for request 2 during context rederivation. It looks like the expected HMAC output is compared against itself, so the received context ID from the request is not validated.