### PR TITLE
Simplify ConnectionStore names.

### DIFF
--- a/MIGRATION_HINTS_4.md
+++ b/MIGRATION_HINTS_4.md
@@ -19,10 +19,14 @@ If a 3.0.0 or newer is used, it's recommended to update first to 3.13.0 and clea
 
 Some of the configuration properties are not longer supported (they have been marked as deprecated) and it is recommended to generate new property files and compare the content with the ones previous in use.
 
+The major update is also used to simplify some names, which have grown in length over the time. With removing alternative implementations these names has also be shortened.
+
 ## Base Lines
 
 The plan is still to be able to use Californium with java 8. 
-That requires also to use Android 8, API level 26. According a discussion, it is possible to [desugaring](https://github.com/eclipse-californium/californium/issues/1664#issuecomment-1893991987) java 8 back to Android versions before
+That requires also to use Android 8, API level 26. According a discussion, it is possible to [desugaring](https://github.com/eclipse-californium/californium/issues/1664#issuecomment-1893991987) java 8 back to Android versions before. 
+
+**Note:** as for now (January 2025) the android example doesn't compile anymore. if that gets fixed in the future depends the on the interest and contribution.
 
 For a local build new Java versions will be required. For now I would consider to
 support java 17 as minimum version to build Californium.
@@ -108,7 +112,7 @@ Change scope of `DTLSFlight.wrapMessage` to `private`.
 
 The names `CipherSuite.TLS_ECDHE_PSK_WITH_AES_256_GCM_SHA378`, and `CipherSuite.TLS_PSK_WITH_AES_256_GCM_SHA378` are corrected into `CipherSuite.TLS_ECDHE_PSK_WITH_AES_256_GCM_SHA384`, and `CipherSuite.TLS_PSK_WITH_AES_256_GCM_SHA384`. 
 
-Merged `ReadWriteLockConnectionStore` into `ResumptionSupportingConnectionStore` and remove obsolete `ReadWriteLockConnectionStore`.
+Merged `ReadWriteLockConnectionStore` into `ResumptionSupportingConnectionStore` and renamed this into `ConnectionStore`. Remove obsolete `ReadWriteLockConnectionStore`. Also renames `InMemoryReadWriteLockConnectionStore` into `InMemoryConnectionStore`.
 
 Uses the new introduced `ProtocolScheduledExecutorService`.
 

--- a/californium-tests/californium-integration-tests/src/test/java/org/eclipse/californium/integration/test/NatTestHelper.java
+++ b/californium-tests/californium-integration-tests/src/test/java/org/eclipse/californium/integration/test/NatTestHelper.java
@@ -61,7 +61,7 @@ import org.eclipse.californium.scandium.dtls.AlertMessage;
 import org.eclipse.californium.scandium.dtls.ConnectionIdGenerator;
 import org.eclipse.californium.scandium.dtls.DebugConnectionStore;
 import org.eclipse.californium.scandium.dtls.NodeConnectionIdGenerator;
-import org.eclipse.californium.scandium.dtls.ResumptionSupportingConnectionStore;
+import org.eclipse.californium.scandium.dtls.ConnectionStore;
 import org.eclipse.californium.scandium.dtls.SingleNodeConnectionIdGenerator;
 import org.eclipse.californium.scandium.dtls.cipher.CipherSuite;
 import org.eclipse.californium.scandium.dtls.pskstore.SinglePskStore;
@@ -448,7 +448,7 @@ public class NatTestHelper {
 
 	private static class MyDtlsConnector extends DTLSConnector {
 
-		public MyDtlsConnector(DtlsConnectorConfig configuration, ResumptionSupportingConnectionStore connectionStore) {
+		public MyDtlsConnector(DtlsConnectorConfig configuration, ConnectionStore connectionStore) {
 			super(configuration, connectionStore);
 
 		}
@@ -457,7 +457,7 @@ public class NatTestHelper {
 	private static class MyDtlsClusterConnector extends DtlsManagedClusterConnector {
 
 		public MyDtlsClusterConnector(DtlsConnectorConfig configuration,
-				DtlsClusterConnectorConfig clusterConfiguration, ResumptionSupportingConnectionStore connectionStore) {
+				DtlsClusterConnectorConfig clusterConfiguration, ConnectionStore connectionStore) {
 			super(configuration, clusterConfiguration, connectionStore);
 		}
 	}

--- a/demo-apps/cf-extplugtest-server/src/main/resources/logback.xml
+++ b/demo-apps/cf-extplugtest-server/src/main/resources/logback.xml
@@ -126,7 +126,7 @@
 	<logger name="org.eclipse.californium.scandium.dtls.resumption.AsyncResumptionVerifier" level="INFO" additivity="false">
 		<appender-ref ref="STDOUT" />
 	</logger>
-	<logger name="org.eclipse.californium.scandium.dtls.InMemoryReadWriteLockConnectionStore" level="INFO" additivity="false">
+	<logger name="org.eclipse.californium.scandium.dtls.InMemoryConnectionStore" level="INFO" additivity="false">
 		<appender-ref ref="STDOUT" />
 	</logger>
 	<logger name="org.eclipse.californium.cluster.DtlsClusterManager" level="INFO" additivity="false">

--- a/scandium-core/src/main/java/org/eclipse/californium/scandium/DTLSConnector.java
+++ b/scandium-core/src/main/java/org/eclipse/californium/scandium/DTLSConnector.java
@@ -217,14 +217,14 @@ import org.eclipse.californium.scandium.dtls.HandshakeResult;
 import org.eclipse.californium.scandium.dtls.HandshakeResultHandler;
 import org.eclipse.californium.scandium.dtls.Handshaker;
 import org.eclipse.californium.scandium.dtls.HelloVerifyRequest;
-import org.eclipse.californium.scandium.dtls.InMemoryReadWriteLockConnectionStore;
+import org.eclipse.californium.scandium.dtls.InMemoryConnectionStore;
 import org.eclipse.californium.scandium.dtls.MaxFragmentLengthExtension;
 import org.eclipse.californium.scandium.dtls.ProtocolVersion;
 import org.eclipse.californium.scandium.dtls.Record;
 import org.eclipse.californium.scandium.dtls.RecordLayer;
 import org.eclipse.californium.scandium.dtls.ResumingClientHandshaker;
 import org.eclipse.californium.scandium.dtls.ResumingServerHandshaker;
-import org.eclipse.californium.scandium.dtls.ResumptionSupportingConnectionStore;
+import org.eclipse.californium.scandium.dtls.ConnectionStore;
 import org.eclipse.californium.scandium.dtls.ServerHandshaker;
 import org.eclipse.californium.scandium.dtls.SessionAdapter;
 import org.eclipse.californium.scandium.dtls.SessionId;
@@ -318,7 +318,7 @@ public class DTLSConnector implements Connector, PersistentComponent, RecordLaye
 	 */
 	private final String serializationLabel;
 
-	private final ResumptionSupportingConnectionStore connectionStore;
+	private final ConnectionStore connectionStore;
 
 	/**
 	 * Maximum number of connections.
@@ -542,8 +542,8 @@ public class DTLSConnector implements Connector, PersistentComponent, RecordLaye
 	 * @return connection store
 	 * @since 3.0 (moved SessionCache from parameter to configuration)
 	 */
-	protected static ResumptionSupportingConnectionStore createConnectionStore(DtlsConnectorConfig configuration) {
-		return new InMemoryReadWriteLockConnectionStore(
+	protected static ConnectionStore createConnectionStore(DtlsConnectorConfig configuration) {
+		return new InMemoryConnectionStore(
 				configuration.get(DtlsConfig.DTLS_MAX_CONNECTIONS),
 				configuration.get(DtlsConfig.DTLS_STALE_CONNECTION_THRESHOLD, TimeUnit.SECONDS),
 				configuration.getSessionStore(),
@@ -568,7 +568,7 @@ public class DTLSConnector implements Connector, PersistentComponent, RecordLaye
 	 *             generator.
 	 */
 	protected DTLSConnector(final DtlsConnectorConfig configuration,
-			final ResumptionSupportingConnectionStore connectionStore) {
+			final ConnectionStore connectionStore) {
 		if (configuration == null) {
 			throw new NullPointerException("Configuration must not be null");
 		} else if (connectionStore == null) {
@@ -1427,7 +1427,7 @@ public class DTLSConnector implements Connector, PersistentComponent, RecordLaye
 	 * Destroys the connector.
 	 * <p>
 	 * This method invokes {@link #stop()} and clears the
-	 * {@link ResumptionSupportingConnectionStore} used to manage connections to
+	 * {@link ConnectionStore} used to manage connections to
 	 * peers. Thus, contrary to the behavior specified for
 	 * {@link Connector#destroy()}, this connector can be re-started using the
 	 * {@link #start()} method but subsequent invocations of the

--- a/scandium-core/src/main/java/org/eclipse/californium/scandium/DtlsBindingPreprocessingConnector.java
+++ b/scandium-core/src/main/java/org/eclipse/californium/scandium/DtlsBindingPreprocessingConnector.java
@@ -19,7 +19,7 @@ package org.eclipse.californium.scandium;
 import org.eclipse.californium.scandium.config.DtlsConnectorConfig;
 import org.eclipse.californium.scandium.dtls.ConnectionId;
 import org.eclipse.californium.scandium.dtls.Record;
-import org.eclipse.californium.scandium.dtls.ResumptionSupportingConnectionStore;
+import org.eclipse.californium.scandium.dtls.ConnectionStore;
 
 import java.net.InetSocketAddress;
 import java.util.List;
@@ -113,11 +113,11 @@ public class DtlsBindingPreprocessingConnector extends DTLSConnector {
 	}
 
 	/**
-	 * @see DTLSConnector#DTLSConnector(DtlsConnectorConfig, ResumptionSupportingConnectionStore)
+	 * @see DTLSConnector#DTLSConnector(DtlsConnectorConfig, ConnectionStore)
 	 * @param configuration The configuration options.
 	 * @param connectionStore The registry to use for managing connections to peers.
 	 */
-	public DtlsBindingPreprocessingConnector(DtlsConnectorConfig configuration, ResumptionSupportingConnectionStore connectionStore) {
+	public DtlsBindingPreprocessingConnector(DtlsConnectorConfig configuration, ConnectionStore connectionStore) {
 		super(configuration, connectionStore);
 	}
 

--- a/scandium-core/src/main/java/org/eclipse/californium/scandium/DtlsClusterConnector.java
+++ b/scandium-core/src/main/java/org/eclipse/californium/scandium/DtlsClusterConnector.java
@@ -40,7 +40,7 @@ import org.eclipse.californium.scandium.dtls.ConnectionId;
 import org.eclipse.californium.scandium.dtls.ContentType;
 import org.eclipse.californium.scandium.dtls.NodeConnectionIdGenerator;
 import org.eclipse.californium.scandium.dtls.Record;
-import org.eclipse.californium.scandium.dtls.ResumptionSupportingConnectionStore;
+import org.eclipse.californium.scandium.dtls.ConnectionStore;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -195,7 +195,7 @@ public class DtlsClusterConnector extends DTLSConnector {
 	 *             {@link NodeConnectionIdGenerator}.
 	 */
 	protected DtlsClusterConnector(DtlsConnectorConfig configuration, DtlsClusterConnectorConfig clusterConfiguration,
-			ResumptionSupportingConnectionStore connectionStore, boolean startReceiver) {
+			ConnectionStore connectionStore, boolean startReceiver) {
 		super(configuration, connectionStore);
 		this.nodeCidGenerator = getNodeConnectionIdGenerator();
 		this.clusterInternalSocketAddress = clusterConfiguration.getAddress();

--- a/scandium-core/src/main/java/org/eclipse/californium/scandium/DtlsManagedClusterConnector.java
+++ b/scandium-core/src/main/java/org/eclipse/californium/scandium/DtlsManagedClusterConnector.java
@@ -41,7 +41,7 @@ import org.eclipse.californium.scandium.dtls.DTLSContext;
 import org.eclipse.californium.scandium.dtls.HandshakeException;
 import org.eclipse.californium.scandium.dtls.Handshaker;
 import org.eclipse.californium.scandium.dtls.NodeConnectionIdGenerator;
-import org.eclipse.californium.scandium.dtls.ResumptionSupportingConnectionStore;
+import org.eclipse.californium.scandium.dtls.ConnectionStore;
 import org.eclipse.californium.scandium.dtls.SessionAdapter;
 import org.eclipse.californium.scandium.dtls.pskstore.SinglePskStore;
 import org.eclipse.californium.scandium.util.SecretUtil;
@@ -132,7 +132,7 @@ public class DtlsManagedClusterConnector extends DtlsClusterConnector {
 	 *             {@link NodeConnectionIdGenerator}.
 	 */
 	protected DtlsManagedClusterConnector(DtlsConnectorConfig configuration,
-			DtlsClusterConnectorConfig clusterConfiguration, ResumptionSupportingConnectionStore connectionStore) {
+			DtlsClusterConnectorConfig clusterConfiguration, ConnectionStore connectionStore) {
 		super(configuration, clusterConfiguration, connectionStore, false);
 		String identity = clusterConfiguration.getSecureIdentity();
 		Integer mgmtReceiveBuffer = addConditionally(config.get(DtlsConfig.DTLS_RECEIVE_BUFFER_SIZE), MAX_DATAGRAM_OFFSET);

--- a/scandium-core/src/main/java/org/eclipse/californium/scandium/config/DtlsConnectorConfig.java
+++ b/scandium-core/src/main/java/org/eclipse/californium/scandium/config/DtlsConnectorConfig.java
@@ -61,11 +61,11 @@ import org.eclipse.californium.scandium.dtls.CertificateRequest;
 import org.eclipse.californium.scandium.dtls.CertificateType;
 import org.eclipse.californium.scandium.dtls.ConnectionIdGenerator;
 import org.eclipse.californium.scandium.dtls.HelloVerifyRequest;
-import org.eclipse.californium.scandium.dtls.InMemoryReadWriteLockConnectionStore;
+import org.eclipse.californium.scandium.dtls.InMemoryConnectionStore;
 import org.eclipse.californium.scandium.dtls.MultiNodeConnectionIdGenerator;
 import org.eclipse.californium.scandium.dtls.ProtocolVersion;
 import org.eclipse.californium.scandium.dtls.Record;
-import org.eclipse.californium.scandium.dtls.ResumptionSupportingConnectionStore;
+import org.eclipse.californium.scandium.dtls.ConnectionStore;
 import org.eclipse.californium.scandium.dtls.SessionListener;
 import org.eclipse.californium.scandium.dtls.SessionStore;
 import org.eclipse.californium.scandium.dtls.SignatureAndHashAlgorithm;
@@ -261,9 +261,9 @@ public final class DtlsConnectorConfig {
 	private DatagramFilter datagramFilter;
 
 	/**
-	 * Session store for {@link InMemoryReadWriteLockConnectionStore}.
+	 * Session store for {@link InMemoryConnectionStore}.
 	 * 
-	 * If a custom {@link ResumptionSupportingConnectionStore} is used, the
+	 * If a custom {@link ConnectionStore} is used, the
 	 * session store must be provided directly to that implementation. In that
 	 * case, the configured session store here will be ignored.
 	 * 
@@ -730,9 +730,9 @@ public final class DtlsConnectorConfig {
 	}
 
 	/**
-	 * Gets session store for {@link InMemoryReadWriteLockConnectionStore}.
+	 * Gets session store for {@link InMemoryConnectionStore}.
 	 * 
-	 * If a custom {@link ResumptionSupportingConnectionStore} is used, the
+	 * If a custom {@link ConnectionStore} is used, the
 	 * session store must be provided directly to that implementation. In that
 	 * case, the configured session store here will be ignored.
 	 * 
@@ -753,7 +753,7 @@ public final class DtlsConnectorConfig {
 	 * implementation may check a maximum time, or, if the credentials are
 	 * expired (e.g. x509 valid range). The default verifier will just checks,
 	 * if a DTLS session with that session id is available in the
-	 * {@link ResumptionSupportingConnectionStore}.
+	 * {@link ConnectionStore}.
 	 * 
 	 * @return resumption verifier. May be {@code null}, if
 	 *         {@link DtlsConfig#DTLS_SERVER_USE_SESSION_ID} is {@code false} and session
@@ -1286,9 +1286,9 @@ public final class DtlsConnectorConfig {
 		}
 
 		/**
-		 * Sets the session store for {@link InMemoryReadWriteLockConnectionStore}.
+		 * Sets the session store for {@link InMemoryConnectionStore}.
 		 * 
-		 * If a custom {@link ResumptionSupportingConnectionStore} is used, the
+		 * If a custom {@link ConnectionStore} is used, the
 		 * session store must be provided directly to that implementation. In
 		 * that case, the configured session store here will be ignored.
 		 * 
@@ -1313,7 +1313,7 @@ public final class DtlsConnectorConfig {
 		 * available. An implementation may check a maximum time, or, if the
 		 * credentials are expired (e.g. x509 valid range). The default verifier
 		 * will just checks, if a DTLS session with that session id is available
-		 * in the {@link ResumptionSupportingConnectionStore}.
+		 * in the {@link ConnectionStore}.
 		 * 
 		 * @param resumptionVerifier the resumption verifier
 		 * @return this builder for command chaining.

--- a/scandium-core/src/main/java/org/eclipse/californium/scandium/dtls/Connection.java
+++ b/scandium-core/src/main/java/org/eclipse/californium/scandium/dtls/Connection.java
@@ -357,9 +357,9 @@ public final class Connection {
 	 * 
 	 * Note: to keep track of the associated address in the connection store,
 	 * this method must not be called directly. It must be called by calling
-	 * {@link ResumptionSupportingConnectionStore#update(Connection, InetSocketAddress)}
+	 * {@link ConnectionStore#update(Connection, InetSocketAddress)}
 	 * or
-	 * {@link ResumptionSupportingConnectionStore#remove(Connection, boolean)}.
+	 * {@link ConnectionStore#remove(Connection, boolean)}.
 	 * 
 	 * @param peerAddress the address of the peer
 	 * @throws IllegalArgumentException if the address should be updated with a

--- a/scandium-core/src/main/java/org/eclipse/californium/scandium/dtls/ConnectionEvictedException.java
+++ b/scandium-core/src/main/java/org/eclipse/californium/scandium/dtls/ConnectionEvictedException.java
@@ -15,7 +15,7 @@ package org.eclipse.californium.scandium.dtls;
 
 /**
  * Raised when a connection is evicted from
- * {@link ResumptionSupportingConnectionStore}
+ * {@link ConnectionStore}
  * 
  * @since 2.3
  */

--- a/scandium-core/src/main/java/org/eclipse/californium/scandium/dtls/ConnectionStore.java
+++ b/scandium-core/src/main/java/org/eclipse/californium/scandium/dtls/ConnectionStore.java
@@ -34,11 +34,11 @@ import java.util.concurrent.locks.ReentrantReadWriteLock.WriteLock;
 import org.eclipse.californium.scandium.ConnectionListener;
 
 /**
- * A connection store which adds support of connection resumption.
+ * A connection.
  * 
- * @since 1.1
+ * @since 4.0 (Rename ResumptionSupportingConnectionStore into ConnectionStore)
  */
-public interface ResumptionSupportingConnectionStore extends Iterable<Connection> {
+public interface ConnectionStore extends Iterable<Connection> {
 
 	/**
 	 * Set connection listener.

--- a/scandium-core/src/main/java/org/eclipse/californium/scandium/dtls/InMemoryConnectionStore.java
+++ b/scandium-core/src/main/java/org/eclipse/californium/scandium/dtls/InMemoryConnectionStore.java
@@ -46,7 +46,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 /**
- * An in-memory {@code ReadWriteLockConnectionStore} with a configurable maximum
+ * An in-memory {@code ConnectionStore} with a configurable maximum
  * capacity and support for evicting stale connections based on a <em>least
  * recently update</em> policy.
  * <p>
@@ -88,11 +88,11 @@ import org.slf4j.LoggerFactory;
  * the session get's removed also from the session store.
  * </p>
  * 
- * @since 3.5
+ * @since 4.0 (Rename InMemoryReadWriteLockConnectionStore into InMemoryConnectionStore)
  */
-public class InMemoryReadWriteLockConnectionStore implements ResumptionSupportingConnectionStore {
+public class InMemoryConnectionStore implements ConnectionStore {
 
-	private static final Logger LOGGER = LoggerFactory.getLogger(InMemoryReadWriteLockConnectionStore.class);
+	private static final Logger LOGGER = LoggerFactory.getLogger(InMemoryConnectionStore.class);
 	private static final FilteredLogger WARN_FILTER = new FilteredLogger(LOGGER.getName(), 3, TimeUnit.SECONDS.toNanos(10));
 
 	// extra cid bytes additionally to required bytes for small capacity.
@@ -132,7 +132,7 @@ public class InMemoryReadWriteLockConnectionStore implements ResumptionSupportin
 	 * @param uniquePrincipals {@code true}, to limit stale connections by
 	 *            unique principals, {@code false}, if not.
 	 */
-	public InMemoryReadWriteLockConnectionStore(int capacity, long threshold, SessionStore sessionStore,
+	public InMemoryConnectionStore(int capacity, long threshold, SessionStore sessionStore,
 			boolean uniquePrincipals) {
 		this.connections = new LeastRecentlyUpdatedCache<>(capacity, threshold, TimeUnit.SECONDS);
 		this.connectionsByAddress = new ConcurrentHashMap<>();
@@ -156,7 +156,7 @@ public class InMemoryReadWriteLockConnectionStore implements ResumptionSupportin
 						if (handshaker != null) {
 							handshaker.handshakeFailed(new ConnectionEvictedException("Evicted!"));
 						}
-						synchronized (InMemoryReadWriteLockConnectionStore.this) {
+						synchronized (InMemoryConnectionStore.this) {
 							removeByAddressConnections(staleConnection);
 							removeByEstablishedSessions(staleConnection.getEstablishedSessionIdentifier(),
 									staleConnection);
@@ -186,7 +186,7 @@ public class InMemoryReadWriteLockConnectionStore implements ResumptionSupportin
 	 * @param tag tag for logging
 	 * @return this connection store for calls chaining
 	 */
-	public synchronized InMemoryReadWriteLockConnectionStore setTag(final String tag) {
+	public synchronized InMemoryConnectionStore setTag(final String tag) {
 		this.tag = StringUtil.normalizeLoggingTag(tag);
 		return this;
 	}

--- a/scandium-core/src/main/java/org/eclipse/californium/scandium/dtls/SessionStore.java
+++ b/scandium-core/src/main/java/org/eclipse/californium/scandium/dtls/SessionStore.java
@@ -23,7 +23,7 @@ package org.eclipse.californium.scandium.dtls;
 /**
  * A second level store for current state of DTLS sessions.
  * <p>
- * Used for {@link InMemoryReadWriteLockConnectionStore}. Session state can be
+ * Used for {@link InMemoryConnectionStore}. Session state can be
  * put to the store and later retrieved by the DTLS session's ID for resumption
  * handshakes. The provided store is required to be thread-safe because it will
  * be accessed concurrently. If used, the sessions are weakly consistent with
@@ -36,7 +36,7 @@ package org.eclipse.californium.scandium.dtls;
  * That was mainly also the situation before 3.0.
  * 
  * Note: using this interface for the
- * {@link InMemoryReadWriteLockConnectionStore} is not well tested! If used and
+ * {@link InMemoryConnectionStore} is not well tested! If used and
  * causing trouble, don't hesitate to create an issue.
  * 
  * @since 3.0 (renamed SessionCache)

--- a/scandium-core/src/main/java/org/eclipse/californium/scandium/dtls/resumption/AsyncResumptionVerifier.java
+++ b/scandium-core/src/main/java/org/eclipse/californium/scandium/dtls/resumption/AsyncResumptionVerifier.java
@@ -25,7 +25,7 @@ import org.eclipse.californium.scandium.DTLSConnector;
 import org.eclipse.californium.scandium.dtls.ConnectionId;
 import org.eclipse.californium.scandium.dtls.HandshakeResultHandler;
 import org.eclipse.californium.scandium.dtls.ResumptionVerificationResult;
-import org.eclipse.californium.scandium.dtls.ResumptionSupportingConnectionStore;
+import org.eclipse.californium.scandium.dtls.ConnectionStore;
 import org.eclipse.californium.scandium.dtls.SessionId;
 import org.eclipse.californium.scandium.util.ServerNames;
 import org.slf4j.Logger;
@@ -33,7 +33,7 @@ import org.slf4j.LoggerFactory;
 
 /**
  * Asynchronous test implementation using the provided
- * {@link ResumptionSupportingConnectionStore}.
+ * {@link ConnectionStore}.
  * 
  * Use {@code 0} or negative delays for test with synchronous blocking behavior.
  * And positive delays for test with asynchronous none-blocking behavior.
@@ -67,7 +67,7 @@ public class AsyncResumptionVerifier extends ConnectionStoreResumptionVerifier {
 
 	/**
 	 * Create a resumption verifier based on the
-	 * {@link ResumptionSupportingConnectionStore} of the {@link DTLSConnector}.
+	 * {@link ConnectionStore} of the {@link DTLSConnector}.
 	 * 
 	 * A call to {@link #shutdown()} is required to cleanup the used resources
 	 * (executor).
@@ -79,14 +79,14 @@ public class AsyncResumptionVerifier extends ConnectionStoreResumptionVerifier {
 
 	/**
 	 * Create a resumption verifier based on the provided
-	 * {@link ResumptionSupportingConnectionStore}.
+	 * {@link ConnectionStore}.
 	 * 
 	 * A call to {@link #shutdown()} is required to cleanup the used resources
 	 * (executor).
 	 * 
 	 * @param connectionStore connection store to lookup the dtls session.
 	 */
-	public AsyncResumptionVerifier(ResumptionSupportingConnectionStore connectionStore) {
+	public AsyncResumptionVerifier(ConnectionStore connectionStore) {
 		super(connectionStore);
 		this.executorService = ExecutorsUtil.newSingleThreadScheduledExecutor(THREAD_FACTORY); // $NON-NLS-1$
 	}

--- a/scandium-core/src/main/java/org/eclipse/californium/scandium/dtls/resumption/ConnectionStoreResumptionVerifier.java
+++ b/scandium-core/src/main/java/org/eclipse/californium/scandium/dtls/resumption/ConnectionStoreResumptionVerifier.java
@@ -19,17 +19,17 @@ import org.eclipse.californium.scandium.DTLSConnector;
 import org.eclipse.californium.scandium.dtls.ConnectionId;
 import org.eclipse.californium.scandium.dtls.DTLSSession;
 import org.eclipse.californium.scandium.dtls.HandshakeResultHandler;
-import org.eclipse.californium.scandium.dtls.ResumptionSupportingConnectionStore;
+import org.eclipse.californium.scandium.dtls.ConnectionStore;
 import org.eclipse.californium.scandium.dtls.ResumptionVerificationResult;
 import org.eclipse.californium.scandium.dtls.SessionId;
 import org.eclipse.californium.scandium.util.ServerNames;
 
 /**
  * Resumption verifier using the provided
- * {@link ResumptionSupportingConnectionStore}.
+ * {@link ConnectionStore}.
  * 
- * If not {@link ResumptionSupportingConnectionStore} is provided with
- * {@link #setConnectionStore(ResumptionSupportingConnectionStore)}, the
+ * If not {@link ConnectionStore} is provided with
+ * {@link #setConnectionStore(ConnectionStore)}, the
  * {@link DTLSConnector} will set its connection store as default on
  * initialization.
  * 
@@ -40,22 +40,22 @@ public class ConnectionStoreResumptionVerifier implements ResumptionVerifier {
 	/**
 	 * Connection store to lookup the dtls session.
 	 */
-	private volatile ResumptionSupportingConnectionStore connectionStore;
+	private volatile ConnectionStore connectionStore;
 
 	/**
 	 * Create a resumption verifier based on the
-	 * {@link ResumptionSupportingConnectionStore} of the {@link DTLSConnector}.
+	 * {@link ConnectionStore} of the {@link DTLSConnector}.
 	 */
 	public ConnectionStoreResumptionVerifier() {
 	}
 
 	/**
 	 * Create a resumption verifier based on the provided
-	 * {@link ResumptionSupportingConnectionStore}.
+	 * {@link ConnectionStore}.
 	 * 
 	 * @param connectionStore connection store to lookup the dtls session.
 	 */
-	public ConnectionStoreResumptionVerifier(ResumptionSupportingConnectionStore connectionStore) {
+	public ConnectionStoreResumptionVerifier(ConnectionStore connectionStore) {
 		setConnectionStore(connectionStore);
 	}
 
@@ -75,7 +75,7 @@ public class ConnectionStoreResumptionVerifier implements ResumptionVerifier {
 	 * @param connectionStore connection store
 	 * @throws NullPointerException if the connection store is {@code null}.
 	 */
-	public void setConnectionStore(ResumptionSupportingConnectionStore connectionStore) {
+	public void setConnectionStore(ConnectionStore connectionStore) {
 		if (connectionStore == null) {
 			throw new NullPointerException("Connection store must not be null!");
 		}

--- a/scandium-core/src/main/java/org/eclipse/californium/scandium/dtls/resumption/ResumptionVerifier.java
+++ b/scandium-core/src/main/java/org/eclipse/californium/scandium/dtls/resumption/ResumptionVerifier.java
@@ -19,7 +19,7 @@ import org.eclipse.californium.scandium.DTLSConnector;
 import org.eclipse.californium.scandium.dtls.ConnectionId;
 import org.eclipse.californium.scandium.dtls.HandshakeResultHandler;
 import org.eclipse.californium.scandium.dtls.ResumptionVerificationResult;
-import org.eclipse.californium.scandium.dtls.ResumptionSupportingConnectionStore;
+import org.eclipse.californium.scandium.dtls.ConnectionStore;
 import org.eclipse.californium.scandium.dtls.SessionId;
 import org.eclipse.californium.scandium.util.ServerNames;
 
@@ -30,7 +30,7 @@ import org.eclipse.californium.scandium.util.ServerNames;
  * to verify, if there is a valid session to resume. An implementation may check
  * a maximum time, or, if the credentials are expired (e.g. x509 valid range).
  * The default verifier will just checks, if a DTLS session with that session id
- * is available in the {@link ResumptionSupportingConnectionStore}.
+ * is available in the {@link ConnectionStore}.
  * 
  * @since 4.0 (removed skipRequestHelloVerify)
  */

--- a/scandium-core/src/test/java/org/eclipse/californium/scandium/ConnectorHelper.java
+++ b/scandium-core/src/test/java/org/eclipse/californium/scandium/ConnectorHelper.java
@@ -87,13 +87,13 @@ import org.eclipse.californium.scandium.dtls.DTLSConnectionState;
 import org.eclipse.californium.scandium.dtls.DTLSContext;
 import org.eclipse.californium.scandium.dtls.DTLSSession;
 import org.eclipse.californium.scandium.dtls.DebugConnectionStore;
-import org.eclipse.californium.scandium.dtls.DebugReadWriteLockConnectionStore;
+import org.eclipse.californium.scandium.dtls.DebugInMemoryConnectionStore;
 import org.eclipse.californium.scandium.dtls.DtlsTestTools;
 import org.eclipse.californium.scandium.dtls.HandshakeException;
 import org.eclipse.californium.scandium.dtls.Handshaker;
 import org.eclipse.californium.scandium.dtls.TestInMemorySessionStore;
 import org.eclipse.californium.scandium.dtls.Record;
-import org.eclipse.californium.scandium.dtls.ResumptionSupportingConnectionStore;
+import org.eclipse.californium.scandium.dtls.ConnectionStore;
 import org.eclipse.californium.scandium.dtls.SessionAdapter;
 import org.eclipse.californium.scandium.dtls.SessionId;
 import org.eclipse.californium.scandium.dtls.SessionStore;
@@ -303,7 +303,7 @@ public class ConnectorHelper {
 	}
 
 	public DTLSConnector createClient(DtlsConnectorConfig configuration,
-			ResumptionSupportingConnectionStore connectionStore) {
+			ConnectionStore connectionStore) {
 		return new DtlsTestConnector(configuration, connectionStore);
 	}
 
@@ -425,7 +425,7 @@ public class ConnectorHelper {
 
 	public static DebugConnectionStore createDebugConnectionStore(Configuration configuration,
 			SessionStore sessionStore) {
-		return new DebugReadWriteLockConnectionStore(configuration.get(DtlsConfig.DTLS_MAX_CONNECTIONS),
+		return new DebugInMemoryConnectionStore(configuration.get(DtlsConfig.DTLS_MAX_CONNECTIONS),
 					configuration.get(DtlsConfig.DTLS_STALE_CONNECTION_THRESHOLD, TimeUnit.SECONDS), sessionStore,
 					configuration.get(DtlsConfig.DTLS_REMOVE_STALE_DOUBLE_PRINCIPALS));
 	}
@@ -869,7 +869,7 @@ public class ConnectorHelper {
 			});
 		}
 
-		DtlsTestConnector(DtlsConnectorConfig configuration, ResumptionSupportingConnectionStore connectionStore) {
+		DtlsTestConnector(DtlsConnectorConfig configuration, ConnectionStore connectionStore) {
 			super(configuration, connectionStore);
 			addSessionListener(new SessionAdapter() {
 

--- a/scandium-core/src/test/java/org/eclipse/californium/scandium/DTLSConnectorAdvancedTest.java
+++ b/scandium-core/src/test/java/org/eclipse/californium/scandium/DTLSConnectorAdvancedTest.java
@@ -112,7 +112,7 @@ import org.eclipse.californium.scandium.dtls.Record;
 import org.eclipse.californium.scandium.dtls.RecordLayer;
 import org.eclipse.californium.scandium.dtls.ResumingClientHandshaker;
 import org.eclipse.californium.scandium.dtls.ResumingServerHandshaker;
-import org.eclipse.californium.scandium.dtls.ResumptionSupportingConnectionStore;
+import org.eclipse.californium.scandium.dtls.ConnectionStore;
 import org.eclipse.californium.scandium.dtls.ResumptionVerificationResult;
 import org.eclipse.californium.scandium.dtls.ServerHandshaker;
 import org.eclipse.californium.scandium.dtls.SessionId;
@@ -204,7 +204,7 @@ public class DTLSConnectorAdvancedTest {
 	AsyncCertificateVerifier clientCertificateVerifier;
 	DtlsConnectorConfig.Builder clientConfigBuilder;
 	DTLSConnector client;
-	ResumptionSupportingConnectionStore clientConnectionStore;
+	ConnectionStore clientConnectionStore;
 	List<Record> lastReceivedFlight;
 	List<Record> lastSentFlight;
 

--- a/scandium-core/src/test/java/org/eclipse/californium/scandium/DTLSConnectorResumeTest.java
+++ b/scandium-core/src/test/java/org/eclipse/californium/scandium/DTLSConnectorResumeTest.java
@@ -81,7 +81,7 @@ import org.eclipse.californium.scandium.dtls.Connection;
 import org.eclipse.californium.scandium.dtls.DTLSSession;
 import org.eclipse.californium.scandium.dtls.DtlsTestTools;
 import org.eclipse.californium.scandium.dtls.ExtendedMasterSecretMode;
-import org.eclipse.californium.scandium.dtls.ResumptionSupportingConnectionStore;
+import org.eclipse.californium.scandium.dtls.ConnectionStore;
 import org.eclipse.californium.scandium.dtls.SessionId;
 import org.eclipse.californium.scandium.dtls.TestInMemorySessionStore;
 import org.eclipse.californium.scandium.dtls.cipher.CipherSuite;
@@ -152,7 +152,7 @@ public class DTLSConnectorResumeTest {
 
 	Class<?> clientPrincipalType;
 	DTLSConnector client;
-	ResumptionSupportingConnectionStore clientConnectionStore;
+	ConnectionStore clientConnectionStore;
 	DtlsHealthLogger clientHealth;
 
 	public static interface TypedBuilderSetup extends BuilderSetup {
@@ -838,7 +838,7 @@ public class DTLSConnectorResumeTest {
 		// second client with same address
 		DtlsConnectorConfig clientConfig2 = createClientConfigBuilder("client-2", clientTestContext.getClientAddress())
 				.set(DtlsConfig.DTLS_USE_SERVER_NAME_INDICATION, true).build();
-		ResumptionSupportingConnectionStore clientConnectionStore2 = ConnectorHelper.createDebugConnectionStore(clientConfig2);
+		ConnectionStore clientConnectionStore2 = ConnectorHelper.createDebugConnectionStore(clientConfig2);
 		
 		DTLSConnector client2 = new DTLSConnector(clientConfig2, clientConnectionStore2);
 		client2.setExecutor(executor);

--- a/scandium-core/src/test/java/org/eclipse/californium/scandium/DTLSConnectorTest.java
+++ b/scandium-core/src/test/java/org/eclipse/californium/scandium/DTLSConnectorTest.java
@@ -116,12 +116,12 @@ import org.eclipse.californium.scandium.dtls.HandshakeType;
 import org.eclipse.californium.scandium.dtls.Handshaker;
 import org.eclipse.californium.scandium.dtls.HelloRequest;
 import org.eclipse.californium.scandium.dtls.HelloVerifyRequest;
-import org.eclipse.californium.scandium.dtls.InMemoryReadWriteLockConnectionStore;
+import org.eclipse.californium.scandium.dtls.InMemoryConnectionStore;
 import org.eclipse.californium.scandium.dtls.PSKClientKeyExchange;
 import org.eclipse.californium.scandium.dtls.ProtocolVersion;
 import org.eclipse.californium.scandium.dtls.PskPublicInformation;
 import org.eclipse.californium.scandium.dtls.Record;
-import org.eclipse.californium.scandium.dtls.ResumptionSupportingConnectionStore;
+import org.eclipse.californium.scandium.dtls.ConnectionStore;
 import org.eclipse.californium.scandium.dtls.SessionId;
 import org.eclipse.californium.scandium.dtls.cipher.CipherSuite;
 import org.eclipse.californium.scandium.dtls.pskstore.PskStore;
@@ -178,7 +178,7 @@ public class DTLSConnectorTest {
 	DTLSConnector client;
 	TestContext clientTestContext;
 	DTLSContext establishedClientContext;
-	ResumptionSupportingConnectionStore clientConnectionStore;
+	ConnectionStore clientConnectionStore;
 
 	@BeforeClass
 	public static void loadKeys() throws IOException, GeneralSecurityException {
@@ -717,7 +717,7 @@ public class DTLSConnectorTest {
 		// the same IP address and port again
 		clientTestContext.setLatchCount(1);
 		DtlsConnectorConfig clientConfig = newClientConfigBuilder().setAddress(clientTestContext.getClientAddress()).build();
-		ResumptionSupportingConnectionStore clientConnectionStore = ConnectorHelper.createDebugConnectionStore(clientConfig);
+		ConnectionStore clientConnectionStore = ConnectorHelper.createDebugConnectionStore(clientConfig);
 		client = new DTLSConnector(clientConfig, clientConnectionStore);
 		client.setRawDataReceiver(clientTestContext.getChannel());
 		client.setExecutor(executor);
@@ -1057,7 +1057,7 @@ public class DTLSConnectorTest {
 
 	@Test
 	public void testConnectorTerminatesHandshakeIfConnectionStoreIsExhausted() throws Exception {
-		logging.setLoggingLevel("ERROR", InMemoryReadWriteLockConnectionStore.class);
+		logging.setLoggingLevel("ERROR", InMemoryConnectionStore.class);
 		serverHelper.serverConnectionStore.clear();
 		assertEquals(SERVER_CONNECTION_STORE_CAPACITY, serverHelper.serverConnectionStore.remainingCapacity());
 		assertTrue(serverHelper.serverConnectionStore.put(new Connection(new InetSocketAddress("192.168.0.1", 5050))

--- a/scandium-core/src/test/java/org/eclipse/californium/scandium/DTLSEndpointContextTest.java
+++ b/scandium-core/src/test/java/org/eclipse/californium/scandium/DTLSEndpointContextTest.java
@@ -49,7 +49,7 @@ import org.eclipse.californium.scandium.config.DtlsConnectorConfig;
 import org.eclipse.californium.scandium.dtls.Connection;
 import org.eclipse.californium.scandium.dtls.DTLSContext;
 import org.eclipse.californium.scandium.dtls.DTLSSession;
-import org.eclipse.californium.scandium.dtls.ResumptionSupportingConnectionStore;
+import org.eclipse.californium.scandium.dtls.ConnectionStore;
 import org.eclipse.californium.scandium.rule.DtlsNetworkRule;
 import org.junit.After;
 import org.junit.AfterClass;
@@ -88,7 +88,7 @@ public class DTLSEndpointContextTest {
 	DtlsConnectorConfig clientConfig;
 	DTLSContext establishedClientContext;
 	DTLSSession establishedClientSession;
-	ResumptionSupportingConnectionStore clientConnectionStore;
+	ConnectionStore clientConnectionStore;
 
 	/**
 	 * Configures and starts a server side connector for running the tests

--- a/scandium-core/src/test/java/org/eclipse/californium/scandium/DtlsClusterConnectorTest.java
+++ b/scandium-core/src/test/java/org/eclipse/californium/scandium/DtlsClusterConnectorTest.java
@@ -43,7 +43,7 @@ import org.eclipse.californium.scandium.config.DtlsConfig;
 import org.eclipse.californium.scandium.config.DtlsConnectorConfig;
 import org.eclipse.californium.scandium.dtls.Connection;
 import org.eclipse.californium.scandium.dtls.MultiNodeConnectionIdGenerator;
-import org.eclipse.californium.scandium.dtls.ResumptionSupportingConnectionStore;
+import org.eclipse.californium.scandium.dtls.ConnectionStore;
 import org.eclipse.californium.scandium.dtls.SingleNodeConnectionIdGenerator;
 import org.eclipse.californium.scandium.dtls.pskstore.SinglePskStore;
 import org.eclipse.californium.scandium.rule.DtlsNetworkRule;
@@ -87,7 +87,7 @@ public class DtlsClusterConnectorTest {
 	private static Configuration configuration;
 
 	private DTLSConnector clientConnector;
-	private ResumptionSupportingConnectionStore clientConnections;
+	private ConnectionStore clientConnections;
 	private LatchDecrementingRawDataChannel clientChannel;
 
 	@BeforeClass

--- a/scandium-core/src/test/java/org/eclipse/californium/scandium/DtlsManagedClusterConnectorTest.java
+++ b/scandium-core/src/test/java/org/eclipse/californium/scandium/DtlsManagedClusterConnectorTest.java
@@ -50,7 +50,7 @@ import org.eclipse.californium.scandium.config.DtlsConfig;
 import org.eclipse.californium.scandium.config.DtlsConnectorConfig;
 import org.eclipse.californium.scandium.dtls.Connection;
 import org.eclipse.californium.scandium.dtls.MultiNodeConnectionIdGenerator;
-import org.eclipse.californium.scandium.dtls.ResumptionSupportingConnectionStore;
+import org.eclipse.californium.scandium.dtls.ConnectionStore;
 import org.eclipse.californium.scandium.dtls.pskstore.SinglePskStore;
 import org.eclipse.californium.scandium.rule.DtlsNetworkRule;
 import org.eclipse.californium.scandium.util.SecretUtil;
@@ -118,7 +118,7 @@ public class DtlsManagedClusterConnectorTest {
 	private DtlsClusterHealthLogger health2;
 
 	private DTLSConnector clientConnector;
-	private ResumptionSupportingConnectionStore clientConnections;
+	private ConnectionStore clientConnections;
 	private LatchDecrementingRawDataChannel clientChannel;
 	private DtlsHealthLogger clientHealth;
 

--- a/scandium-core/src/test/java/org/eclipse/californium/scandium/HelloExtensionNegotiationTest.java
+++ b/scandium-core/src/test/java/org/eclipse/californium/scandium/HelloExtensionNegotiationTest.java
@@ -46,7 +46,7 @@ import org.eclipse.californium.scandium.config.DtlsConfig;
 import org.eclipse.californium.scandium.config.DtlsConnectorConfig;
 import org.eclipse.californium.scandium.config.DtlsConnectorConfig.Builder;
 import org.eclipse.californium.scandium.dtls.MaxFragmentLengthExtension.Length;
-import org.eclipse.californium.scandium.dtls.ResumptionSupportingConnectionStore;
+import org.eclipse.californium.scandium.dtls.ConnectionStore;
 import org.eclipse.californium.scandium.rule.DtlsNetworkRule;
 import org.junit.After;
 import org.junit.AfterClass;
@@ -75,7 +75,7 @@ public class HelloExtensionNegotiationTest {
 	DtlsConnectorConfig clientConfig;
 	DTLSConnector client;
 	InetSocketAddress clientEndpoint;
-	ResumptionSupportingConnectionStore clientConnectionStore;
+	ConnectionStore clientConnectionStore;
 
 	/**
 	 * Configures and starts a server side connector for running the tests against.

--- a/scandium-core/src/test/java/org/eclipse/californium/scandium/dtls/DebugConnectionStore.java
+++ b/scandium-core/src/test/java/org/eclipse/californium/scandium/dtls/DebugConnectionStore.java
@@ -25,7 +25,7 @@ import java.net.InetSocketAddress;
  * 
  * @since 3.5
  */
-public interface DebugConnectionStore extends ResumptionSupportingConnectionStore {
+public interface DebugConnectionStore extends ConnectionStore {
 
 	/**
 	 * Set logging tag.
@@ -33,7 +33,7 @@ public interface DebugConnectionStore extends ResumptionSupportingConnectionStor
 	 * @param tag logging tag
 	 * @return this connection store
 	 */
-	ResumptionSupportingConnectionStore setTag(String tag);
+	ConnectionStore setTag(String tag);
 
 	/**
 	 * Dump connections to logger. Intended to be used for unit tests.

--- a/scandium-core/src/test/java/org/eclipse/californium/scandium/dtls/DebugInMemoryConnectionStore.java
+++ b/scandium-core/src/test/java/org/eclipse/californium/scandium/dtls/DebugInMemoryConnectionStore.java
@@ -30,10 +30,10 @@ import org.slf4j.LoggerFactory;
  * 
  * @since 3.5
  */
-public final class DebugReadWriteLockConnectionStore extends InMemoryReadWriteLockConnectionStore
+public final class DebugInMemoryConnectionStore extends InMemoryConnectionStore
 		implements DebugConnectionStore {
 
-	private static final Logger LOG = LoggerFactory.getLogger(DebugReadWriteLockConnectionStore.class);
+	private static final Logger LOG = LoggerFactory.getLogger(DebugInMemoryConnectionStore.class);
 
 	/**
 	 * Creates a store based on given configuration parameters.
@@ -47,7 +47,7 @@ public final class DebugReadWriteLockConnectionStore extends InMemoryReadWriteLo
 	 * @param uniquePrincipals {@code true}, to limit stale connections by
 	 *            unique principals, {@code false}, if not.
 	 */
-	public DebugReadWriteLockConnectionStore(int capacity, long threshold, SessionStore sessionStore,
+	public DebugInMemoryConnectionStore(int capacity, long threshold, SessionStore sessionStore,
 			boolean uniquePrincipals) {
 		super(capacity, threshold, sessionStore, uniquePrincipals);
 	}

--- a/scandium-core/src/test/java/org/eclipse/californium/scandium/dtls/InMemoryConnectionStoreTest.java
+++ b/scandium-core/src/test/java/org/eclipse/californium/scandium/dtls/InMemoryConnectionStoreTest.java
@@ -74,7 +74,7 @@ public class InMemoryConnectionStoreTest {
 	public LoggingRule logging = new LoggingRule();
 
 	private static final int INITIAL_CAPACITY = 10;
-	ResumptionSupportingConnectionStore store;
+	ConnectionStore store;
 	Connection con;
 	SessionId sessionId;
 
@@ -140,7 +140,7 @@ public class InMemoryConnectionStoreTest {
 		// another node
 		SessionStore sessionStore = new TestInMemorySessionStore(true);
 		sessionStore.put(con.getEstablishedSession());
-		store = new InMemoryReadWriteLockConnectionStore(INITIAL_CAPACITY, 1000, sessionStore, true);
+		store = new InMemoryConnectionStore(INITIAL_CAPACITY, 1000, sessionStore, true);
 		store.attach(null);
 
 		// WHEN retrieving the connection for the given peer
@@ -158,7 +158,7 @@ public class InMemoryConnectionStoreTest {
 		// and a (local) connection based on this session
 		SessionStore sessionStore = new TestInMemorySessionStore(true);
 		sessionStore.put(con.getEstablishedSession());
-		store = new InMemoryReadWriteLockConnectionStore(INITIAL_CAPACITY, 1000, sessionStore, true);
+		store = new InMemoryConnectionStore(INITIAL_CAPACITY, 1000, sessionStore, true);
 		store.attach(null);
 		store.put(con);
 
@@ -340,7 +340,7 @@ public class InMemoryConnectionStoreTest {
 
 	@Test
 	public void testPutEvictsStaleOldConnection() throws Exception {
-		store = new InMemoryReadWriteLockConnectionStore(2, 1, null, true);
+		store = new InMemoryConnectionStore(2, 1, null, true);
 		store.attach(null);
 
 		// given an empty connection store
@@ -356,8 +356,8 @@ public class InMemoryConnectionStoreTest {
 		// assert that the store has two entries
 		assertThat(store.remainingCapacity(), is(0));
 
-		if (store instanceof InMemoryReadWriteLockConnectionStore) {
-			Map<Principal, Connection> connectionsByPrincipal = ((InMemoryReadWriteLockConnectionStore) store).connectionsByPrincipal;
+		if (store instanceof InMemoryConnectionStore) {
+			Map<Principal, Connection> connectionsByPrincipal = ((InMemoryConnectionStore) store).connectionsByPrincipal;
 			if (connectionsByPrincipal != null) {
 				assertThat(connectionsByPrincipal.size(), is(2));
 			}
@@ -370,8 +370,8 @@ public class InMemoryConnectionStoreTest {
 		// assert that the store has still two entries
 		assertThat(store.remainingCapacity(), is(0));
 
-		if (store instanceof InMemoryReadWriteLockConnectionStore) {
-			Map<Principal, Connection> connectionsByPrincipal = ((InMemoryReadWriteLockConnectionStore) store).connectionsByPrincipal;
+		if (store instanceof InMemoryConnectionStore) {
+			Map<Principal, Connection> connectionsByPrincipal = ((InMemoryConnectionStore) store).connectionsByPrincipal;
 			if (connectionsByPrincipal != null) {
 				assertThat(connectionsByPrincipal.size(), is(2));
 			}
@@ -411,7 +411,7 @@ public class InMemoryConnectionStoreTest {
 
 	@Test
 	public void testSaveAndLoadMaliciousConnections() throws Exception {
-		logging.setLoggingLevel("ERROR", InMemoryReadWriteLockConnectionStore.class);
+		logging.setLoggingLevel("ERROR", InMemoryConnectionStore.class);
 
 		assertThat(store.remainingCapacity(), is(INITIAL_CAPACITY));
 		assertTrue(store.put(con));


### PR DESCRIPTION
Rename ResumptionSupportingConnectionStore into ConnectionStore and InMemoryReadWriteLockConnectionStore into InMemoryConnectionStore.