### PR TITLE
better support for application level authentication

### DIFF
--- a/MIGRATION_HINTS_4.md
+++ b/MIGRATION_HINTS_4.md
@@ -62,6 +62,8 @@ Supports virtual threads for DTLS receivers, if the JVM supports it. Otherwise p
 
 The `DTLSConnector` uses Connection ID to identify DLTS context now also for outgoing messages, if available.
 
+The `DefaultCipherSuiteSelector` supports now `CertificateAuthenticationMode.WANTED` even if no common client certificate type is available. It omits the `CertificateRequest` in this case.
+
 ### Element-Connector-TCP-Netty:
 
 ### Californium-Core:

--- a/MIGRATION_HINTS_4.md
+++ b/MIGRATION_HINTS_4.md
@@ -64,6 +64,10 @@ The `DTLSConnector` uses Connection ID to identify DLTS context now also for out
 
 The `DefaultCipherSuiteSelector` supports now `CertificateAuthenticationMode.WANTED` even if no common client certificate type is available. It omits the `CertificateRequest` in this case.
 
+The `InMemoryConnectionStore` removes now `Connection`s without `Principals` when the ip-address is reused.
+
+Using the `DTLS.APPLICATION_AUTHORIZATION_TIMEOUT` removes now connections with anonymous clients after that timeout, if the application doesn't authorize them using the `ApplicationAuthorizer`.
+
 ### Element-Connector-TCP-Netty:
 
 ### Californium-Core:

--- a/MIGRATION_HINTS_4.md
+++ b/MIGRATION_HINTS_4.md
@@ -128,6 +128,8 @@ Rename `Connection.refreshAutoResumptionTime` into `updateLastMessageNanos`.
 
 `DTLSConnector.cleanupRecentHandshakes` returns `int` instead of `void`.
 
+Remove `restoreConnection` from `DTLSConnector`.
+
 ### Californium-Core:
 
 The functions of the obsolete and removed `ExtendedCoapStack` are moved into

--- a/MIGRATION_HINTS_4.md
+++ b/MIGRATION_HINTS_4.md
@@ -120,6 +120,8 @@ Remove the "Advanced" from PSK-stores. Replace `AdvancedPskStore` by `PskStore`,
 
 Remove the "NewAdvanced" from CertificateVerifier. Replace `NewAdvancedCertificateVerifier` by `CertificateVerifier`, `StaticNewAdvancedCertificateVerifier` by `StaticCertificateVerifier` and `AsyncNewAdvancedCertificateVerifier` by `AsyncCertificateVerifier`.
 
+Rename `Connection.refreshAutoResumptionTime` into `updateLastMessageNanos`.
+
 ### Californium-Core:
 
 The functions of the obsolete and removed `ExtendedCoapStack` are moved into

--- a/MIGRATION_HINTS_4.md
+++ b/MIGRATION_HINTS_4.md
@@ -60,6 +60,8 @@ In some cases `SHA384` was misspelled as `SHA378`. That's fixed but causes also 
 
 Supports virtual threads for DTLS receivers, if the JVM supports it. Otherwise platform daemon threads are used. Chosen by `-1` as number of threads in `DTLS.RECEIVER_THREAD_COUNT`.
 
+The `DTLSConnector` uses Connection ID to identify DLTS context now also for outgoing messages, if available.
+
 ### Element-Connector-TCP-Netty:
 
 ### Californium-Core:
@@ -121,6 +123,8 @@ Remove the "Advanced" from PSK-stores. Replace `AdvancedPskStore` by `PskStore`,
 Remove the "NewAdvanced" from CertificateVerifier. Replace `NewAdvancedCertificateVerifier` by `CertificateVerifier`, `StaticNewAdvancedCertificateVerifier` by `StaticCertificateVerifier` and `AsyncNewAdvancedCertificateVerifier` by `AsyncCertificateVerifier`.
 
 Rename `Connection.refreshAutoResumptionTime` into `updateLastMessageNanos`.
+
+`DTLSConnector.cleanupRecentHandshakes` returns `int` instead of `void`.
 
 ### Californium-Core:
 

--- a/californium-core/src/main/java/org/eclipse/californium/core/network/CoapEndpoint.java
+++ b/californium-core/src/main/java/org/eclipse/californium/core/network/CoapEndpoint.java
@@ -131,6 +131,7 @@ import org.eclipse.californium.elements.RawData;
 import org.eclipse.californium.elements.RawDataChannel;
 import org.eclipse.californium.elements.UDPConnector;
 import org.eclipse.californium.elements.UdpMulticastConnector;
+import org.eclipse.californium.elements.auth.ApplicationAuthorizer;
 import org.eclipse.californium.elements.config.Configuration;
 import org.eclipse.californium.elements.util.ClockUtil;
 import org.eclipse.californium.elements.util.DaemonThreadFactory;
@@ -228,6 +229,13 @@ public class CoapEndpoint implements Endpoint, Executor {
 
 	/** The connector over which the endpoint connects to the network */
 	private final Connector connector;
+
+	/**
+	 * Application authorizer for anonymous client support.
+	 * 
+	 * @since 4.0
+	 */
+	private final ApplicationAuthorizer authorizer;
 
 	private final String scheme;
 
@@ -389,6 +397,7 @@ public class CoapEndpoint implements Endpoint, Executor {
 		}
 		this.config = config;
 		this.connector = connector;
+		this.authorizer = (connector instanceof ApplicationAuthorizer) ? (ApplicationAuthorizer) connector : null;
 		this.connector.setRawDataReceiver(new InboxImpl());
 		this.scheme = CoAP.getSchemeForProtocol(connector.getProtocol());
 		this.multicastBaseMid = config.get(CoapConfig.MULTICAST_BASE_MID);
@@ -1337,6 +1346,11 @@ public class CoapEndpoint implements Endpoint, Executor {
 	@Override
 	public void cancelObservation(Token token) {
 		matcher.cancelObserve(token);
+	}
+
+	@Override
+	public ApplicationAuthorizer getApplicationAuthorizer() {
+		return authorizer;
 	}
 
 	/**

--- a/californium-core/src/main/java/org/eclipse/californium/core/network/Endpoint.java
+++ b/californium-core/src/main/java/org/eclipse/californium/core/network/Endpoint.java
@@ -35,6 +35,7 @@ import org.eclipse.californium.core.network.stack.CoapStack;
 import org.eclipse.californium.core.observe.NotificationListener;
 import org.eclipse.californium.core.server.MessageDeliverer;
 import org.eclipse.californium.elements.Connector;
+import org.eclipse.californium.elements.auth.ApplicationAuthorizer;
 import org.eclipse.californium.elements.config.Configuration;
 import org.eclipse.californium.elements.util.ProtocolScheduledExecutorService;
 
@@ -286,4 +287,13 @@ public interface Endpoint {
 	 * @throws IllegalArgumentException if the token has client-local scope.
 	 */
 	void cancelObservation(Token token);
+
+	/**
+	 * Gets application authorizer.
+	 * 
+	 * @return application authorizer, or {@code null}, if not supported by this
+	 *         endpoint.
+	 * @since 4.0
+	 */
+	ApplicationAuthorizer getApplicationAuthorizer();
 }

--- a/californium-core/src/main/java/org/eclipse/californium/core/network/Exchange.java
+++ b/californium-core/src/main/java/org/eclipse/californium/core/network/Exchange.java
@@ -81,6 +81,7 @@ import org.eclipse.californium.elements.Connector;
 import org.eclipse.californium.elements.EndpointContext;
 import org.eclipse.californium.elements.EndpointIdentityResolver;
 import org.eclipse.californium.elements.UdpMulticastConnector;
+import org.eclipse.californium.elements.auth.ApplicationAuthorizer;
 import org.eclipse.californium.elements.util.CheckedExecutor;
 import org.eclipse.californium.elements.util.ClockUtil;
 import org.eclipse.californium.elements.util.SerialExecutor;
@@ -859,6 +860,18 @@ public class Exchange {
 	 */
 	public Object getPeersIdentity() {
 		return peersIdentity;
+	}
+
+	/**
+	 * Gets application authorizer.
+	 * 
+	 * @return application authorizer, or {@code null}, if not supported by this
+	 *         exchange.
+	 * @since 4.0
+	 */
+	public ApplicationAuthorizer getApplicationAuthorizer() {
+		Endpoint endpoint = getEndpoint();
+		return endpoint == null ? null : endpoint.getApplicationAuthorizer();
 	}
 
 	/**

--- a/californium-core/src/main/java/org/eclipse/californium/core/observe/ObserveRelation.java
+++ b/californium-core/src/main/java/org/eclipse/californium/core/observe/ObserveRelation.java
@@ -569,7 +569,7 @@ public class ObserveRelation {
 		}
 		boolean noNotification = result == State.NONE || result == State.CANCELED;
 		if (response.isNotification() && (!response.isSuccess() || noNotification)) {
-			LOGGER.warn("Application notification, not longer observing, remove observe-option {}", response);
+			LOGGER.info("Application notification, not longer observing, remove observe-option {}", response);
 			response.getOptions().removeObserve();
 		}
 		return result;

--- a/californium-core/src/main/java/org/eclipse/californium/core/server/resources/CoapExchange.java
+++ b/californium-core/src/main/java/org/eclipse/californium/core/server/resources/CoapExchange.java
@@ -22,6 +22,7 @@ package org.eclipse.californium.core.server.resources;
 
 import java.net.InetAddress;
 import java.net.InetSocketAddress;
+import java.security.Principal;
 
 import org.eclipse.californium.core.CoapResource;
 import org.eclipse.californium.core.coap.CoAP.Code;
@@ -37,6 +38,7 @@ import org.eclipse.californium.elements.DtlsEndpointContext;
 import org.eclipse.californium.elements.EndpointContext;
 import org.eclipse.californium.elements.MapBasedEndpointContext;
 import org.eclipse.californium.elements.MapBasedEndpointContext.Attributes;
+import org.eclipse.californium.elements.auth.ApplicationAuthorizer;
 import org.eclipse.californium.elements.UdpMulticastConnector;
 
 /**
@@ -70,13 +72,34 @@ public class CoapExchange {
 	}
 
 	/**
+	 * Gets the source principal.
+	 *
+	 * @return the source principal. May be {@code null}, if source is
+	 *         anonymous.
+	 * @since 4.0
+	 */
+	public final Principal getSourcePrincipal() {
+		return getSourceContext().getPeerIdentity();
+	}
+
+	/**
+	 * Gets the source context.
+	 *
+	 * @return the source context.
+	 * @since 4.0
+	 */
+	public final EndpointContext getSourceContext() {
+		return exchange.getRequest().getSourceContext();
+	}
+
+	/**
 	 * Gets the source socket address of the request.
 	 *
 	 * @return the source socket address
 	 * @since 2.1
 	 */
-	public InetSocketAddress getSourceSocketAddress() {
-		return exchange.getRequest().getSourceContext().getPeerAddress();
+	public final InetSocketAddress getSourceSocketAddress() {
+		return getSourceContext().getPeerAddress();
 	}
 
 	/**
@@ -84,8 +107,8 @@ public class CoapExchange {
 	 *
 	 * @return the source address
 	 */
-	public InetAddress getSourceAddress() {
-		return exchange.getRequest().getSourceContext().getPeerAddress().getAddress();
+	public final InetAddress getSourceAddress() {
+		return getSourceSocketAddress().getAddress();
 	}
 
 	/**
@@ -93,8 +116,19 @@ public class CoapExchange {
 	 *
 	 * @return the source port
 	 */
-	public int getSourcePort() {
-		return exchange.getRequest().getSourceContext().getPeerAddress().getPort();
+	public final int getSourcePort() {
+		return getSourceSocketAddress().getPort();
+	}
+
+	/**
+	 * Gets application authorizer.
+	 * 
+	 * @return application authorizer, or {@code null}, if not supported by this
+	 *         exchange.
+	 * @since 4.0
+	 */
+	public ApplicationAuthorizer getApplicationAuthorizer() {
+		return exchange.getApplicationAuthorizer();
 	}
 
 	/**

--- a/californium-core/src/test/java/org/eclipse/californium/core/server/ServerPersistenceComponentsTest.java
+++ b/californium-core/src/test/java/org/eclipse/californium/core/server/ServerPersistenceComponentsTest.java
@@ -47,6 +47,7 @@ import org.eclipse.californium.elements.rule.LoggingRule;
 import org.eclipse.californium.elements.util.DataStreamReader;
 import org.eclipse.californium.elements.util.DatagramWriter;
 import org.eclipse.californium.elements.util.EncryptedPersistentComponentUtil;
+import org.eclipse.californium.elements.util.EncryptedStreamUtil;
 import org.eclipse.californium.elements.util.PersistentComponentUtil;
 import org.eclipse.californium.elements.util.SerializationUtil;
 import org.eclipse.californium.rule.CoapNetworkRule;
@@ -106,6 +107,7 @@ public class ServerPersistenceComponentsTest {
 		util.saveComponents(out, 1000);
 		ByteArrayInputStream in = new ByteArrayInputStream(out.toByteArray());
 		util = setup(connector2);
+		logging.setLoggingLevel("ERROR", PersistentComponentUtil.class);
 		util.loadComponents(in);
 		assertThat(connector1.data, is(nullValue()));
 		assertArrayEquals(connector2.mark, connector2.data);
@@ -118,6 +120,7 @@ public class ServerPersistenceComponentsTest {
 		util.saveComponents(out, 1000);
 		ByteArrayInputStream in = new ByteArrayInputStream(out.toByteArray());
 		util = setup(connector1);
+		logging.setLoggingLevel("ERROR", PersistentComponentUtil.class);
 		util.loadComponents(in);
 		assertArrayEquals(connector1.mark, connector1.data);
 		assertThat(connector2.data, is(nullValue()));
@@ -155,6 +158,7 @@ public class ServerPersistenceComponentsTest {
 		util.saveComponents(out, key, 1000);
 		ByteArrayInputStream in = new ByteArrayInputStream(out.toByteArray());
 		util = setup(connector2);
+		logging.setLoggingLevel("ERROR", PersistentComponentUtil.class);
 		util.loadComponents(in, key);
 		assertThat(connector1.data, is(nullValue()));
 		assertArrayEquals(connector2.mark, connector2.data);
@@ -168,6 +172,7 @@ public class ServerPersistenceComponentsTest {
 		util.saveComponents(out, key, 1000);
 		ByteArrayInputStream in = new ByteArrayInputStream(out.toByteArray());
 		util = setup(connector1);
+		logging.setLoggingLevel("ERROR", PersistentComponentUtil.class);
 		util.loadComponents(in, key);
 		assertArrayEquals(connector1.mark, connector1.data);
 		assertThat(connector2.data, is(nullValue()));
@@ -181,6 +186,7 @@ public class ServerPersistenceComponentsTest {
 		util.saveComponents(out, key, 1000);
 		ByteArrayInputStream in = new ByteArrayInputStream(out.toByteArray());
 		util = setup(connector1, connector3);
+		logging.setLoggingLevel("ERROR", PersistentComponentUtil.class);
 		util.loadComponents(in, key);
 		assertArrayEquals(connector1.mark, connector1.data);
 		assertThat(connector2.data, is(nullValue()));
@@ -220,7 +226,7 @@ public class ServerPersistenceComponentsTest {
 		ByteArrayOutputStream out = new ByteArrayOutputStream();
 		util.saveComponents(out, 1000);
 		ByteArrayInputStream in = new ByteArrayInputStream(out.toByteArray());
-		logging.setLoggingLevel("ERROR", PersistentComponentUtil.class);
+		logging.setLoggingLevel("ERROR", EncryptedStreamUtil.class);
 		util.loadComponents(in, key);
 		assertThat(connector1.data, is(nullValue()));
 		assertThat(connector2.data, is(nullValue()));

--- a/californium-core/src/test/java/org/eclipse/californium/core/test/ResourceAttributesTest.java
+++ b/californium-core/src/test/java/org/eclipse/californium/core/test/ResourceAttributesTest.java
@@ -41,6 +41,7 @@ import org.eclipse.californium.core.observe.NotificationListener;
 import org.eclipse.californium.core.server.MessageDeliverer;
 import org.eclipse.californium.core.server.resources.DiscoveryResource;
 import org.eclipse.californium.core.server.resources.Resource;
+import org.eclipse.californium.elements.auth.ApplicationAuthorizer;
 import org.eclipse.californium.elements.category.Small;
 import org.eclipse.californium.elements.config.Configuration;
 import org.eclipse.californium.elements.rule.TestNameLoggerRule;
@@ -242,6 +243,11 @@ public class ResourceAttributesTest {
 
 		@Override
 		public List<MessageInterceptor> getPostProcessInterceptors() {
+			return null;
+		}
+
+		@Override
+		public ApplicationAuthorizer getApplicationAuthorizer() {
 			return null;
 		}
 

--- a/californium-core/src/test/resources/logback-test.xml
+++ b/californium-core/src/test/resources/logback-test.xml
@@ -16,7 +16,7 @@
 		<appender-ref ref="STDOUT" />
 	</logger>
 
-	<logger name="org.eclipse.californium.elements.rule.ThreadsRule" level="TRACE" additivity="false">
+	<logger name="org.eclipse.californium.elements.rule.ThreadsRule" level="DEBUG" additivity="false">
 		<appender-ref ref="STDOUT" />
 	</logger>
 

--- a/cf-utils/cf-cli/src/main/java/org/eclipse/californium/cli/ClientInitializer.java
+++ b/cf-utils/cf-cli/src/main/java/org/eclipse/californium/cli/ClientInitializer.java
@@ -398,14 +398,18 @@ public class ClientInitializer {
 				dtlsConfig.setCertificateVerifier(verifierBuilder.build());
 			}
 
-			if (clientConfig.authentication != null && clientConfig.authentication.credentials != null) {
-				Credentials identity = clientConfig.authentication.credentials;
-				if (certificateTypes.contains(CertificateType.X_509)) {
-					dtlsConfig.setCertificateIdentityProvider(new SingleCertificateProvider(identity.getPrivateKey(),
-							identity.getCertificateChain(), certificateTypes));
-				} else if (certificateTypes.contains(CertificateType.RAW_PUBLIC_KEY)) {
-					dtlsConfig.setCertificateIdentityProvider(
-							new SingleCertificateProvider(identity.getPrivateKey(), identity.getPublicKey()));
+			if (clientConfig.authentication != null) {
+				if (clientConfig.authentication.credentials != null) {
+					Credentials identity = clientConfig.authentication.credentials;
+					if (certificateTypes.contains(CertificateType.X_509)) {
+						dtlsConfig.setCertificateIdentityProvider(new SingleCertificateProvider(
+								identity.getPrivateKey(), identity.getCertificateChain(), certificateTypes));
+					} else if (certificateTypes.contains(CertificateType.RAW_PUBLIC_KEY)) {
+						dtlsConfig.setCertificateIdentityProvider(
+								new SingleCertificateProvider(identity.getPrivateKey(), identity.getPublicKey()));
+					}
+				} else if (keyExchangeAlgorithms.isEmpty()) {
+					ListUtils.addIfAbsent(keyExchangeAlgorithms, KeyExchangeAlgorithm.EC_DIFFIE_HELLMAN);
 				}
 			}
 

--- a/demo-apps/cf-cloud-demo-server/README.md
+++ b/demo-apps/cf-cloud-demo-server/README.md
@@ -298,9 +298,9 @@ or
 openssl genpkey -algorithm EC -pkeyopt ec_paramgen_curve:P-256 -out privkey.pem
 ```
 
-as already introduced above.
+as already introduced above for creating device key-pairs.
 
-(The PEM created by that commands contains both, the private and the public key. Therefore the server needs only this one. Other formats or tools may have other results and you may need then two files, one `privkey.pem` and one `publickey.pem`.)
+(As already mentioned, the PEM created by that commands contains both, the private and the public key. Therefore the server needs only this one. Other formats or tools may have other results and you may need then two files, one `privkey.pem` and one `publickey.pem`.)
 
 The `public key` of that server pair must be provided to devices, which then use that to trust this server. How the `public key` is provided depends on the device. If that requires the `public key` in base64 pem, then export it as show above for the device's `key-pair`.
 

--- a/demo-apps/cf-cloud-demo-server/src/main/java/org/eclipse/californium/cloud/BaseServer.java
+++ b/demo-apps/cf-cloud-demo-server/src/main/java/org/eclipse/californium/cloud/BaseServer.java
@@ -49,7 +49,9 @@ import org.eclipse.californium.core.network.interceptors.HealthStatisticLogger;
 import org.eclipse.californium.core.observe.ObserveStatisticLogger;
 import org.eclipse.californium.core.server.resources.Resource;
 import org.eclipse.californium.elements.EndpointContextMatcher;
+import org.eclipse.californium.elements.PrincipalAndAnonymousEndpointContextMatcher;
 import org.eclipse.californium.elements.PrincipalEndpointContextMatcher;
+import org.eclipse.californium.elements.config.CertificateAuthenticationMode;
 import org.eclipse.californium.elements.config.Configuration;
 import org.eclipse.californium.elements.config.Configuration.DefinitionsProvider;
 import org.eclipse.californium.elements.config.IntegerDefinition;
@@ -62,9 +64,9 @@ import org.eclipse.californium.elements.util.EncryptedPersistentComponentUtil;
 import org.eclipse.californium.elements.util.ExecutorsUtil;
 import org.eclipse.californium.elements.util.NamedThreadFactory;
 import org.eclipse.californium.elements.util.NetworkInterfacesUtil;
-import org.eclipse.californium.elements.util.ProtocolScheduledExecutorService;
 import org.eclipse.californium.elements.util.NetworkInterfacesUtil.InetAddressFilter;
 import org.eclipse.californium.elements.util.NetworkInterfacesUtil.SimpleInetAddressFilter;
+import org.eclipse.californium.elements.util.ProtocolScheduledExecutorService;
 import org.eclipse.californium.elements.util.SslContextUtil.Credentials;
 import org.eclipse.californium.elements.util.StringUtil;
 import org.eclipse.californium.elements.util.SystemResourceMonitors;
@@ -202,6 +204,7 @@ public class BaseServer extends CoapServer {
 			config.set(CoapConfig.RESPONSE_MATCHING, MatcherMode.PRINCIPAL_IDENTITY);
 			config.set(CoapConfig.ACK_TIMEOUT, 2500, TimeUnit.MILLISECONDS);
 			config.set(DtlsConfig.DTLS_ROLE, DtlsRole.SERVER_ONLY);
+			config.set(DtlsConfig.DTLS_CLIENT_AUTHENTICATION_MODE, CertificateAuthenticationMode.NEEDED);
 			config.set(DtlsConfig.DTLS_RETRANSMISSION_TIMEOUT, 2500, TimeUnit.MILLISECONDS);
 			config.set(DtlsConfig.DTLS_ADDITIONAL_ECC_TIMEOUT, 8, TimeUnit.SECONDS);
 			config.set(DtlsConfig.DTLS_AUTO_HANDSHAKE_TIMEOUT, null, TimeUnit.SECONDS);
@@ -656,7 +659,11 @@ public class BaseServer extends CoapServer {
 		// Context matcher
 		EndpointContextMatcher customContextMatcher = null;
 		if (MatcherMode.PRINCIPAL == config.get(CoapConfig.RESPONSE_MATCHING)) {
-			customContextMatcher = new PrincipalEndpointContextMatcher(true);
+			if (CertificateAuthenticationMode.NEEDED == config.get(DtlsConfig.DTLS_CLIENT_AUTHENTICATION_MODE)) {
+				customContextMatcher = new PrincipalEndpointContextMatcher(true);
+			} else {
+				customContextMatcher = new PrincipalAndAnonymousEndpointContextMatcher();
+			}
 		}
 
 		// explore network interfaces

--- a/demo-apps/cf-cloud-demo-server/src/main/java/org/eclipse/californium/cloud/resources/ProtectedCoapResource.java
+++ b/demo-apps/cf-cloud-demo-server/src/main/java/org/eclipse/californium/cloud/resources/ProtectedCoapResource.java
@@ -160,9 +160,12 @@ public abstract class ProtectedCoapResource extends CoapResource {
 		final PrincipalInfo info = getPrincipalInfo(exchange);
 		if (info == null) {
 			return UNAUTHORIZED;
-		}
-		if (!allowed(info.type)) {
-			return FORBIDDEN;
+		} else if (!allowed(info.type)) {
+			if (info.type == Type.ANONYMOUS_DEVICE) {
+				return UNAUTHORIZED;
+			} else {
+				return FORBIDDEN;
+			}
 		}
 		return checkOperationPermission(info, exchange, exchange.getRequest().getCode().write);
 	}

--- a/demo-apps/cf-cloud-demo-server/src/main/java/org/eclipse/californium/cloud/util/ApplicationAnonymous.java
+++ b/demo-apps/cf-cloud-demo-server/src/main/java/org/eclipse/californium/cloud/util/ApplicationAnonymous.java
@@ -1,0 +1,58 @@
+/********************************************************************************
+ * Copyright (c) 2025 Contributors to the Eclipse Foundation
+ * 
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ * 
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * https://www.eclipse.org/legal/epl-2.0, or the Eclipse Distribution License
+ * v1.0 which is available at
+ * https://www.eclipse.org/org/documents/edl-v10.php.
+ * 
+ * SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
+ ********************************************************************************/
+package org.eclipse.californium.cloud.util;
+
+import java.security.Principal;
+import java.util.HashMap;
+import java.util.Map;
+
+import org.eclipse.californium.cloud.util.PrincipalInfo.Type;
+import org.eclipse.californium.elements.auth.AdditionalInfo;
+import org.eclipse.californium.elements.auth.ApplicationPrincipal;
+
+/**
+ * Application level anonymous.
+ * 
+ * @since 4.0
+ */
+public class ApplicationAnonymous {
+
+	public static final PrincipalInfo ANONYMOUS_INFO = new PrincipalInfo(ApplicationPrincipal.ANONYMOUS.getName(),
+			ApplicationPrincipal.ANONYMOUS.getName(), Type.ANONYMOUS_DEVICE);
+
+	public static final PrincipalInfo APPL_AUTH_INFO = new PrincipalInfo(ApplicationPrincipal.ANONYMOUS.getName(),
+			ApplicationPrincipal.ANONYMOUS.getName(), Type.APPL_AUTH_DEVICE);
+
+	/**
+	 * Application anonymous principal.
+	 */
+	public static final ApplicationPrincipal APPL_AUTH_PRINCIPAL;
+
+	static {
+		Map<String, Object> info = new HashMap<>();
+		info.put(PrincipalInfo.INFO_NAME, ApplicationPrincipal.ANONYMOUS.getName());
+		info.put(PrincipalInfo.INFO_PROVIDER, new PrincipalInfoProvider() {
+			
+			@Override
+			public PrincipalInfo getPrincipalInfo(Principal principal) {
+				if (ApplicationPrincipal.ANONYMOUS.equals(principal)) {
+					return APPL_AUTH_INFO;
+				}
+				return null;
+			}
+		});
+		APPL_AUTH_PRINCIPAL = ApplicationPrincipal.ANONYMOUS.amend(AdditionalInfo.from(info));
+	}
+}

--- a/demo-apps/cf-cloud-demo-server/src/main/java/org/eclipse/californium/cloud/util/DeviceManager.java
+++ b/demo-apps/cf-cloud-demo-server/src/main/java/org/eclipse/californium/cloud/util/DeviceManager.java
@@ -40,6 +40,7 @@ import javax.security.auth.x500.X500Principal;
 import org.eclipse.californium.cloud.util.DeviceParser.Device;
 import org.eclipse.californium.cloud.util.ResultConsumer.ResultCode;
 import org.eclipse.californium.elements.auth.AdditionalInfo;
+import org.eclipse.californium.elements.auth.ApplicationPrincipal;
 import org.eclipse.californium.elements.auth.ExtensiblePrincipal;
 import org.eclipse.californium.elements.util.CertPathUtil;
 import org.eclipse.californium.elements.util.SslContextUtil.Credentials;
@@ -268,6 +269,9 @@ public class DeviceManager implements DeviceGredentialsProvider, DeviceProvision
 		if (devices == null) {
 			return null;
 		}
+		if (ApplicationPrincipal.ANONYMOUS.equals(clientIdentity)) {
+			return ApplicationAnonymous.APPL_AUTH_PRINCIPAL.getExtendedInfo();
+		}
 		return createAdditionalInfo(devices.getResource().getByPrincipal(clientIdentity));
 	}
 
@@ -388,12 +392,12 @@ public class DeviceManager implements DeviceGredentialsProvider, DeviceProvision
 					LOGGER.info("Certificate validation failed: Raw public key is not trusted");
 					AlertMessage alert = new AlertMessage(AlertLevel.FATAL, AlertDescription.BAD_CERTIFICATE);
 					return new CertificateVerificationResult(cid,
-							new HandshakeException("Raw public key is not trusted!", alert), null);
+							new HandshakeException("Raw public key is not trusted!", alert));
 				} else if (info.isEmpty()) {
 					LOGGER.info("Certificate validation failed: Raw public key is banned");
 					AlertMessage alert = new AlertMessage(AlertLevel.FATAL, AlertDescription.BAD_CERTIFICATE);
 					return new CertificateVerificationResult(cid,
-							new HandshakeException("Raw public key is banned!", alert), null);
+							new HandshakeException("Raw public key is banned!", alert));
 				} else {
 					return new CertificateVerificationResult(cid, publicKey, info);
 				}
@@ -408,7 +412,7 @@ public class DeviceManager implements DeviceGredentialsProvider, DeviceProvision
 							LOGGER.debug("Certificate validation failed: key usage doesn't match");
 							AlertMessage alert = new AlertMessage(AlertLevel.FATAL, AlertDescription.BAD_CERTIFICATE);
 							return new CertificateVerificationResult(cid,
-									new HandshakeException("Key Usage doesn't match!", alert), null);
+									new HandshakeException("Key Usage doesn't match!", alert));
 						}
 						X509Certificate[] trustedCertificates = getTrustedCertificates();
 						if (trustedCertificates == null || trustedCertificates.length == 0) {
@@ -439,12 +443,12 @@ public class DeviceManager implements DeviceGredentialsProvider, DeviceProvision
 							LOGGER.info("Certificate validation failed: x509 certificate is not trusted");
 							AlertMessage alert = new AlertMessage(AlertLevel.FATAL, AlertDescription.BAD_CERTIFICATE);
 							return new CertificateVerificationResult(cid,
-									new HandshakeException("x509 certificate is not trusted!", alert), null);
+									new HandshakeException("x509 certificate is not trusted!", alert));
 						} else if (info.isEmpty()) {
 							LOGGER.info("{}Certificate validation failed: x509 certificate is banned", role);
 							AlertMessage alert = new AlertMessage(AlertLevel.FATAL, AlertDescription.BAD_CERTIFICATE);
 							return new CertificateVerificationResult(cid,
-									new HandshakeException(role + "x509 certificate is banned!", alert), null);
+									new HandshakeException(role + "x509 certificate is banned!", alert));
 						} else {
 							return new CertificateVerificationResult(cid, certChain, info);
 						}
@@ -458,8 +462,7 @@ public class DeviceManager implements DeviceGredentialsProvider, DeviceProvision
 				if (cause instanceof CertificateExpiredException) {
 					LOGGER.debug("Certificate expired: {}", cause.getMessage());
 					AlertMessage alert = new AlertMessage(AlertLevel.FATAL, AlertDescription.CERTIFICATE_EXPIRED);
-					return new CertificateVerificationResult(cid, new HandshakeException("Certificate expired", alert),
-							null);
+					return new CertificateVerificationResult(cid, new HandshakeException("Certificate expired", alert));
 				} else if (cause != null) {
 					LOGGER.debug("Certificate validation failed: {}/{}", e.getMessage(), cause.getMessage());
 				} else {
@@ -467,7 +470,7 @@ public class DeviceManager implements DeviceGredentialsProvider, DeviceProvision
 				}
 				AlertMessage alert = new AlertMessage(AlertLevel.FATAL, AlertDescription.BAD_CERTIFICATE);
 				return new CertificateVerificationResult(cid,
-						new HandshakeException("Certificate chain could not be validated", alert, e), null);
+						new HandshakeException("Certificate chain could not be validated", alert, e));
 			} catch (GeneralSecurityException e) {
 				if (LOGGER.isTraceEnabled()) {
 					LOGGER.trace("Certificate validation failed", e);
@@ -476,7 +479,7 @@ public class DeviceManager implements DeviceGredentialsProvider, DeviceProvision
 				}
 				AlertMessage alert = new AlertMessage(AlertLevel.FATAL, AlertDescription.DECRYPT_ERROR);
 				return new CertificateVerificationResult(cid,
-						new HandshakeException("Certificate chain could not be validated", alert, e), null);
+						new HandshakeException("Certificate chain could not be validated", alert, e));
 			}
 		}
 

--- a/demo-apps/cf-cloud-demo-server/src/main/java/org/eclipse/californium/cloud/util/PrincipalInfo.java
+++ b/demo-apps/cf-cloud-demo-server/src/main/java/org/eclipse/californium/cloud/util/PrincipalInfo.java
@@ -44,6 +44,14 @@ public class PrincipalInfo {
 	public enum Type {
 
 		/**
+		 * Device principal info for anonymous device.
+		 */
+		ANONYMOUS_DEVICE("anon"),
+		/**
+		 * Device principal info for application authorized device.
+		 */
+		APPL_AUTH_DEVICE("appl_auth"),
+		/**
 		 * Device principal info.
 		 */
 		DEVICE("dev"),
@@ -122,6 +130,15 @@ public class PrincipalInfo {
 	 * @param type type of principal
 	 */
 	public PrincipalInfo(String group, String name, Type type) {
+		if (group == null) {
+			throw new NullPointerException("group must not be null!");
+		}
+		if (name == null) {
+			throw new NullPointerException("name must not be null!");
+		}
+		if (type == null) {
+			throw new NullPointerException("type must not be null!");
+		}
 		this.name = name;
 		this.group = group;
 		this.type = type;
@@ -130,6 +147,35 @@ public class PrincipalInfo {
 	@Override
 	public String toString() {
 		return name + " (" + group + "," + type.getShortName() + ")";
+	}
+
+	@Override
+	public int hashCode() {
+		final int prime = 31;
+		int result = 1;
+		result = prime * result + group.hashCode();
+		result = prime * result + name.hashCode();
+		result = prime * result + type.hashCode();
+		return result;
+	}
+
+	@Override
+	public boolean equals(Object obj) {
+		if (this == obj)
+			return true;
+		if (obj == null)
+			return false;
+		if (getClass() != obj.getClass())
+			return false;
+		PrincipalInfo other = (PrincipalInfo) obj;
+		if (!group.equals(other.group)) {
+			return false;
+		} else if (!name.equals(other.name)) {
+			return false;
+		} else if (type != other.type) {
+			return false;
+		}
+		return true;
 	}
 
 	/**
@@ -141,15 +187,19 @@ public class PrincipalInfo {
 	 * @param principal the principal
 	 * @return principal info, or {@code null}, if not available.
 	 * @see EndpointContext#getPeerIdentity()
+	 * @since 4.0 (supports {@link ApplicationAnonymous#ANONYMOUS_INFO}, if
+	 *        {@code null} is provided as principal.)
 	 */
 	public static PrincipalInfo getPrincipalInfo(Principal principal) {
-		if (principal instanceof ExtensiblePrincipal) {
+		if (principal == null) {
+			return ApplicationAnonymous.ANONYMOUS_INFO;
+		} else if (principal instanceof ExtensiblePrincipal) {
 			@SuppressWarnings("unchecked")
 			ExtensiblePrincipal<? extends Principal> extensiblePrincipal = (ExtensiblePrincipal<? extends Principal>) principal;
 			PrincipalInfoProvider provider = extensiblePrincipal.getExtendedInfo().get(INFO_PROVIDER,
 					PrincipalInfoProvider.class);
 			if (provider != null) {
-				return provider.getPrincipalInfo(extensiblePrincipal);
+				return provider.getPrincipalInfo(principal);
 			}
 		}
 		return null;

--- a/demo-apps/cf-extplugtest-client/src/main/java/org/eclipse/californium/extplugtests/BenchmarkClient.java
+++ b/demo-apps/cf-extplugtest-client/src/main/java/org/eclipse/californium/extplugtests/BenchmarkClient.java
@@ -1386,6 +1386,7 @@ public class BenchmarkClient {
 						config.observe.reregister, config.observe.register);
 		}
 		initialConnectDownCounter.set(clients);
+		final boolean anonymous = config.authentication.anonymous;
 		final boolean psk = config.authenticationModes.contains(AuthenticationMode.PSK)
 				|| config.authenticationModes.contains(AuthenticationMode.ECDHE_PSK);
 		final boolean rpk = config.authenticationModes.contains(AuthenticationMode.RPK);
@@ -1412,7 +1413,7 @@ public class BenchmarkClient {
 				break;
 			}
 		}
-		final ThreadLocalKeyPairGenerator keyPairGenerator = rpk ? createKeyPairGenerator() : null;
+		final ThreadLocalKeyPairGenerator keyPairGenerator = (secure && rpk && !anonymous) ? createKeyPairGenerator() : null;
 		// Create & start clients
 		final AtomicBoolean errors = new AtomicBoolean();
 		health = new HealthStatisticLogger(uri.getScheme(), CoAP.isUdpScheme(uri.getScheme()));
@@ -1426,7 +1427,7 @@ public class BenchmarkClient {
 			final int currentIndex = index;
 			final String identity;
 			final SecretKey secret;
-			if (secure && psk) {
+			if (secure && psk && !anonymous) {
 				if (config.pskStore != null) {
 					int pskIndex = (pskOffset + index) % config.pskStore.size();
 					identity = config.pskStore.getIdentity(pskIndex);
@@ -1451,7 +1452,7 @@ public class BenchmarkClient {
 						return;
 					}
 					ClientConfig connectionConfig = config;
-					if (secure) {
+					if (secure && !anonymous) {
 						if (rpk) {
 							if (keyPairGenerator != null) {
 								try {

--- a/demo-apps/cf-extplugtest-server/src/main/java/org/eclipse/californium/extplugtests/ExtendedTestServer.java
+++ b/demo-apps/cf-extplugtest-server/src/main/java/org/eclipse/californium/extplugtests/ExtendedTestServer.java
@@ -57,6 +57,7 @@ import org.eclipse.californium.core.observe.ObserveStatisticLogger;
 import org.eclipse.californium.core.server.resources.MyIpResource;
 import org.eclipse.californium.core.server.resources.Resource;
 import org.eclipse.californium.elements.Connector;
+import org.eclipse.californium.elements.config.CertificateAuthenticationMode;
 import org.eclipse.californium.elements.config.Configuration;
 import org.eclipse.californium.elements.config.Configuration.DefinitionsProvider;
 import org.eclipse.californium.elements.config.SystemConfig;
@@ -162,6 +163,8 @@ public class ExtendedTestServer extends AbstractTestServer {
 			config.set(DtlsConfig.DTLS_MAC_ERROR_FILTER_THRESHOLD, 8);
 			config.set(DtlsConfig.DTLS_RETRANSMISSION_TIMEOUT, 3, TimeUnit.SECONDS);
 			config.set(DtlsConfig.DTLS_ADDITIONAL_ECC_TIMEOUT, 8, TimeUnit.SECONDS);
+			config.set(DtlsConfig.DTLS_CLIENT_AUTHENTICATION_MODE, CertificateAuthenticationMode.WANTED);
+			config.set(DtlsConfig.DTLS_APPLICATION_AUTHORIZATION_TIMEOUT, 15, TimeUnit.SECONDS);
 			config.set(TcpConfig.TCP_CONNECT_TIMEOUT, 15, TimeUnit.SECONDS);
 			config.set(TcpConfig.TCP_CONNECTION_IDLE_TIMEOUT, 60, TimeUnit.MINUTES);
 			config.set(TcpConfig.TLS_HANDSHAKE_TIMEOUT, 60, TimeUnit.SECONDS);

--- a/demo-apps/cf-plugtest-server/src/main/java/org/eclipse/californium/plugtests/AbstractTestServer.java
+++ b/demo-apps/cf-plugtest-server/src/main/java/org/eclipse/californium/plugtests/AbstractTestServer.java
@@ -39,13 +39,13 @@ import javax.net.ssl.X509KeyManager;
 import org.eclipse.californium.core.CoapServer;
 import org.eclipse.californium.core.coap.CoAP;
 import org.eclipse.californium.core.config.CoapConfig;
-import org.eclipse.californium.core.config.CoapConfig.MatcherMode;
 import org.eclipse.californium.core.network.CoapEndpoint;
 import org.eclipse.californium.core.network.Endpoint;
+import org.eclipse.californium.core.network.EndpointContextMatcherFactory;
 import org.eclipse.californium.core.network.interceptors.AnonymizedOriginTracer;
 import org.eclipse.californium.core.network.interceptors.HealthStatisticLogger;
 import org.eclipse.californium.core.network.interceptors.MessageTracer;
-import org.eclipse.californium.elements.PrincipalEndpointContextMatcher;
+import org.eclipse.californium.elements.config.CertificateAuthenticationMode;
 import org.eclipse.californium.elements.config.Configuration;
 import org.eclipse.californium.elements.config.IntegerDefinition;
 import org.eclipse.californium.elements.config.SystemConfig;
@@ -69,8 +69,8 @@ import org.eclipse.californium.scandium.dtls.cipher.CipherSuite;
 import org.eclipse.californium.scandium.dtls.pskstore.AsyncPskStore;
 import org.eclipse.californium.scandium.dtls.pskstore.MultiPskFileStore;
 import org.eclipse.californium.scandium.dtls.resumption.AsyncResumptionVerifier;
-import org.eclipse.californium.scandium.dtls.x509.AsyncKeyManagerCertificateProvider;
 import org.eclipse.californium.scandium.dtls.x509.AsyncCertificateVerifier;
+import org.eclipse.californium.scandium.dtls.x509.AsyncKeyManagerCertificateProvider;
 import org.eclipse.californium.scandium.util.SecretUtil;
 import org.eclipse.californium.scandium.util.ServerNames;
 import org.slf4j.Logger;
@@ -375,9 +375,10 @@ public abstract class AbstractTestServer extends CoapServer {
 					DTLSConnector connector = new DTLSConnector(dtlsConfigBuilder.build());
 					CoapEndpoint.Builder builder = new CoapEndpoint.Builder();
 					builder.setConnector(connector);
-					if (MatcherMode.PRINCIPAL == dtlsConfig.get(CoapConfig.RESPONSE_MATCHING)) {
-						builder.setEndpointContextMatcher(new PrincipalEndpointContextMatcher(true));
-					}
+					boolean anonymous = CertificateAuthenticationMode.NEEDED != dtlsConfig
+							.get(DtlsConfig.DTLS_CLIENT_AUTHENTICATION_MODE);
+					builder.setEndpointContextMatcher(
+							EndpointContextMatcherFactory.create(CoAP.PROTOCOL_DTLS, anonymous, dtlsConfig));
 					builder.setConfiguration(dtlsConfig);
 					CoapEndpoint endpoint = builder.build();
 					addEndpoint(endpoint);

--- a/demo-apps/cf-s3-proxy-server/src/main/java/org/eclipse/californium/cloud/s3/S3ProxyServer.java
+++ b/demo-apps/cf-s3-proxy-server/src/main/java/org/eclipse/californium/cloud/s3/S3ProxyServer.java
@@ -71,6 +71,7 @@ import org.eclipse.californium.core.coap.CoAP;
 import org.eclipse.californium.core.coap.option.MapBasedOptionRegistry;
 import org.eclipse.californium.core.coap.option.OptionRegistry;
 import org.eclipse.californium.core.coap.option.StandardOptionRegistry;
+import org.eclipse.californium.elements.config.CertificateAuthenticationMode;
 import org.eclipse.californium.elements.config.Configuration;
 import org.eclipse.californium.elements.config.Configuration.DefinitionsProvider;
 import org.eclipse.californium.elements.config.IntegerDefinition;
@@ -78,6 +79,7 @@ import org.eclipse.californium.elements.config.TimeDefinition;
 import org.eclipse.californium.elements.util.SslContextUtil.Credentials;
 import org.eclipse.californium.proxy2.config.Proxy2Config;
 import org.eclipse.californium.proxy2.http.HttpClientFactory;
+import org.eclipse.californium.scandium.config.DtlsConfig;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -420,6 +422,8 @@ public class S3ProxyServer extends BaseServer {
 		@Override
 		public void applyDefinitions(Configuration config) {
 			BaseServer.DEFAULTS.applyDefinitions(config);
+			config.set(DtlsConfig.DTLS_CLIENT_AUTHENTICATION_MODE, CertificateAuthenticationMode.WANTED);
+			config.set(DtlsConfig.DTLS_APPLICATION_AUTHORIZATION_TIMEOUT, 15, TimeUnit.SECONDS);
 			config.set(USER_CREDENTIALS_RELOAD_INTERVAL, 30, TimeUnit.SECONDS);
 			config.set(S3_PROCESSING_INITIAL_DELAY, 20, TimeUnit.SECONDS);
 			config.set(S3_PROCESSING_INTERVAL, 0, TimeUnit.HOURS);

--- a/demo-apps/cf-s3-proxy-server/src/main/java/org/eclipse/californium/cloud/s3/forward/BasicHttpForwardConfiguration.java
+++ b/demo-apps/cf-s3-proxy-server/src/main/java/org/eclipse/californium/cloud/s3/forward/BasicHttpForwardConfiguration.java
@@ -21,6 +21,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.regex.Pattern;
 
+import org.eclipse.californium.cloud.s3.util.DomainPrincipalInfo;
 import org.eclipse.californium.cloud.s3.util.Domains;
 import org.eclipse.californium.cloud.util.DeviceParser;
 
@@ -230,7 +231,7 @@ public class BasicHttpForwardConfiguration implements HttpForwardConfiguration, 
 	 * {@link HttpForwardConfigurationProvider} providing itself.
 	 */
 	@Override
-	public HttpForwardConfiguration getConfiguration(String domain, String name) {
+	public HttpForwardConfiguration getConfiguration(DomainPrincipalInfo principalInfo) {
 		return this;
 	}
 

--- a/demo-apps/cf-s3-proxy-server/src/main/java/org/eclipse/californium/cloud/s3/forward/HttpForwardConfigurationProvider.java
+++ b/demo-apps/cf-s3-proxy-server/src/main/java/org/eclipse/californium/cloud/s3/forward/HttpForwardConfigurationProvider.java
@@ -14,6 +14,8 @@
  ********************************************************************************/
 package org.eclipse.californium.cloud.s3.forward;
 
+import org.eclipse.californium.cloud.s3.util.DomainPrincipalInfo;
+
 /**
  * Http forward provider.
  * <p>
@@ -27,11 +29,10 @@ public interface HttpForwardConfigurationProvider {
 	/**
 	 * Gets http forward configuration.
 	 * 
-	 * @param domain domain name
-	 * @param name device name
+	 * @param principalInfo principal info (with domain and device name)
 	 * @return http forward configuration, or {@code null}, if http forwarding
 	 *         is not used.
 	 */
-	HttpForwardConfiguration getConfiguration(String domain, String name);
+	HttpForwardConfiguration getConfiguration(DomainPrincipalInfo principalInfo);
 
 }

--- a/demo-apps/cf-s3-proxy-server/src/main/java/org/eclipse/californium/cloud/s3/forward/HttpForwardConfigurationProviders.java
+++ b/demo-apps/cf-s3-proxy-server/src/main/java/org/eclipse/californium/cloud/s3/forward/HttpForwardConfigurationProviders.java
@@ -17,6 +17,8 @@ package org.eclipse.californium.cloud.s3.forward;
 import java.util.ArrayList;
 import java.util.List;
 
+import org.eclipse.californium.cloud.s3.util.DomainPrincipalInfo;
+
 /**
  * Http forward providers.
  * <p>
@@ -71,10 +73,10 @@ public class HttpForwardConfigurationProviders implements HttpForwardConfigurati
 	 * the one from the general configuration.
 	 */
 	@Override
-	public HttpForwardConfiguration getConfiguration(String domain, String name) {
+	public HttpForwardConfiguration getConfiguration(DomainPrincipalInfo principalInfo) {
 		HttpForwardConfiguration configuration = null;
 		for (HttpForwardConfigurationProvider provider : list) {
-			configuration = BasicHttpForwardConfiguration.merge(configuration, provider.getConfiguration(domain, name));
+			configuration = BasicHttpForwardConfiguration.merge(configuration, provider.getConfiguration(principalInfo));
 		}
 		return configuration;
 	}

--- a/demo-apps/cf-s3-proxy-server/src/main/java/org/eclipse/californium/cloud/s3/http/Aws4Authorizer.java
+++ b/demo-apps/cf-s3-proxy-server/src/main/java/org/eclipse/californium/cloud/s3/http/Aws4Authorizer.java
@@ -516,6 +516,11 @@ public class Aws4Authorizer {
 		public AdditionalInfo getExtendedInfo() {
 			return additionalInfo;
 		}
+
+		@Override
+		public boolean isAnonymous() {
+			return false;
+		}
 	}
 
 	/**

--- a/demo-apps/cf-s3-proxy-server/src/main/java/org/eclipse/californium/cloud/s3/resources/S3ProxyResource.java
+++ b/demo-apps/cf-s3-proxy-server/src/main/java/org/eclipse/californium/cloud/s3/resources/S3ProxyResource.java
@@ -36,6 +36,7 @@ import org.eclipse.californium.cloud.s3.proxy.S3ProxyClientProvider;
 import org.eclipse.californium.cloud.s3.proxy.S3ProxyRequest;
 import org.eclipse.californium.cloud.s3.util.DomainPrincipalInfo;
 import org.eclipse.californium.cloud.util.PrincipalInfo;
+import org.eclipse.californium.cloud.util.PrincipalInfo.Type;
 import org.eclipse.californium.core.coap.CoAP.ResponseCode;
 import org.eclipse.californium.core.coap.Option;
 import org.eclipse.californium.core.coap.Request;
@@ -81,7 +82,7 @@ public class S3ProxyResource extends ProtectedCoapResource {
 	 * @param s3Clients S3 clients
 	 */
 	public S3ProxyResource(String name, int pathStartIndex, Configuration config, S3ProxyClientProvider s3Clients) {
-		super(name);
+		super(name, Type.DEVICE, Type.ANONYMOUS_DEVICE, Type.APPL_AUTH_DEVICE);
 		if (s3Clients == null) {
 			throw new NullPointerException("s3client must not be null!");
 		}

--- a/demo-apps/cf-s3-proxy-server/src/main/java/org/eclipse/californium/cloud/s3/util/DomainApplicationAnonymous.java
+++ b/demo-apps/cf-s3-proxy-server/src/main/java/org/eclipse/californium/cloud/s3/util/DomainApplicationAnonymous.java
@@ -1,0 +1,63 @@
+/********************************************************************************
+ * Copyright (c) 2025 Contributors to the Eclipse Foundation
+ * 
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ * 
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * https://www.eclipse.org/legal/epl-2.0, or the Eclipse Distribution License
+ * v1.0 which is available at
+ * https://www.eclipse.org/org/documents/edl-v10.php.
+ * 
+ * SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
+ ********************************************************************************/
+package org.eclipse.californium.cloud.s3.util;
+
+import java.security.Principal;
+import java.util.HashMap;
+import java.util.Map;
+
+import org.eclipse.californium.cloud.util.PrincipalInfo;
+import org.eclipse.californium.cloud.util.PrincipalInfo.Type;
+import org.eclipse.californium.elements.auth.AdditionalInfo;
+import org.eclipse.californium.elements.auth.ApplicationPrincipal;
+
+/**
+ * Application level anonymous.
+ * 
+ * @since 4.0
+ */
+public class DomainApplicationAnonymous {
+
+	public static final DomainPrincipalInfo ANONYMOUS_INFO = new DomainPrincipalInfo(
+			ApplicationPrincipal.ANONYMOUS.getName(), ApplicationPrincipal.ANONYMOUS.getName(),
+			ApplicationPrincipal.ANONYMOUS.getName(), Type.ANONYMOUS_DEVICE);
+
+	public static final DomainPrincipalInfo APPL_AUTH_INFO = new DomainPrincipalInfo(
+			ApplicationPrincipal.ANONYMOUS.getName(), ApplicationPrincipal.ANONYMOUS.getName(),
+			ApplicationPrincipal.ANONYMOUS.getName(), Type.APPL_AUTH_DEVICE);
+
+	/**
+	 * Application anonymous principal.
+	 */
+	public static final ApplicationPrincipal APPL_AUTH_PRINCIPAL;
+
+	static {
+
+		Map<String, Object> info = new HashMap<>();
+		info.put(PrincipalInfo.INFO_NAME, ApplicationPrincipal.ANONYMOUS.getName());
+		info.put(DomainPrincipalInfo.INFO_DOMAIN, ApplicationPrincipal.ANONYMOUS.getName());
+		info.put(PrincipalInfo.INFO_PROVIDER, new DomainPrincipalInfoProvider() {
+
+			@Override
+			public DomainPrincipalInfo getPrincipalInfo(Principal principal) {
+				if (ApplicationPrincipal.ANONYMOUS.equals(principal)) {
+					return APPL_AUTH_INFO;
+				}
+				return null;
+			}
+		});
+		APPL_AUTH_PRINCIPAL = ApplicationPrincipal.ANONYMOUS.amend(AdditionalInfo.from(info));
+	}
+}

--- a/demo-apps/cf-s3-proxy-server/src/main/java/org/eclipse/californium/cloud/s3/util/DomainDeviceManager.java
+++ b/demo-apps/cf-s3-proxy-server/src/main/java/org/eclipse/californium/cloud/s3/util/DomainDeviceManager.java
@@ -42,6 +42,7 @@ import org.eclipse.californium.cloud.util.ResourceStore;
 import org.eclipse.californium.cloud.util.ResultConsumer;
 import org.eclipse.californium.cloud.util.ResultConsumer.ResultCode;
 import org.eclipse.californium.elements.auth.AdditionalInfo;
+import org.eclipse.californium.elements.auth.ApplicationPrincipal;
 import org.eclipse.californium.elements.auth.ExtensiblePrincipal;
 import org.eclipse.californium.elements.util.CertPathUtil;
 import org.eclipse.californium.elements.util.SslContextUtil.Credentials;
@@ -159,6 +160,9 @@ public class DomainDeviceManager extends DeviceManager
 
 	@Override
 	public AdditionalInfo createAdditionalInfo(Principal clientIdentity) {
+		if (ApplicationPrincipal.ANONYMOUS.equals(clientIdentity)) {
+			return DomainApplicationAnonymous.APPL_AUTH_PRINCIPAL.getExtendedInfo();
+		}
 		for (Entry<String, ResourceStore<DeviceParser>> domain : domains.entrySet()) {
 			Device device = domain.getValue().getResource().getByPrincipal(clientIdentity);
 			if (device != null) {
@@ -237,10 +241,10 @@ public class DomainDeviceManager extends DeviceManager
 	}
 
 	@Override
-	public HttpForwardConfiguration getConfiguration(String domain, String name) {
-		ResourceStore<DeviceParser> resource = domains.get(domain);
+	public HttpForwardConfiguration getConfiguration(DomainPrincipalInfo principalInfo) {
+		ResourceStore<DeviceParser> resource = domains.get(principalInfo.domain);
 		if (resource != null) {
-			Device device = resource.getResource().get(name);
+			Device device = resource.getResource().get(principalInfo.name);
 			if (device != null) {
 				try {
 					return BasicHttpForwardConfiguration.create(device.customFields);

--- a/demo-apps/cf-s3-proxy-server/src/main/java/org/eclipse/californium/cloud/s3/util/DomainPrincipalInfo.java
+++ b/demo-apps/cf-s3-proxy-server/src/main/java/org/eclipse/californium/cloud/s3/util/DomainPrincipalInfo.java
@@ -59,6 +59,38 @@ public class DomainPrincipalInfo extends PrincipalInfo {
 		return name + "@" + domain + " (" + group + "," + type.getShortName() + ")";
 	}
 
+	@Override
+	public int hashCode() {
+		final int prime = 31;
+		int result = 1;
+		result = prime * result + domain.hashCode();
+		result = prime * result + group.hashCode();
+		result = prime * result + name.hashCode();
+		result = prime * result + type.hashCode();
+		return result;
+	}
+
+	@Override
+	public boolean equals(Object obj) {
+		if (this == obj)
+			return true;
+		if (obj == null)
+			return false;
+		if (getClass() != obj.getClass())
+			return false;
+		DomainPrincipalInfo other = (DomainPrincipalInfo) obj;
+		if (!domain.equals(other.domain)) {
+			return false;
+		} else if (!group.equals(other.group)) {
+			return false;
+		} else if (!name.equals(other.name)) {
+			return false;
+		} else if (type != other.type) {
+			return false;
+		}
+		return true;
+	}
+
 	/**
 	 * Gets principal info.
 	 * <p>
@@ -68,9 +100,13 @@ public class DomainPrincipalInfo extends PrincipalInfo {
 	 * @param principal the principal
 	 * @return principal info, or {@code null}, if not available.
 	 * @see EndpointContext#getPeerIdentity()
+	 * @since 4.0 (supports {@link DomainApplicationAnonymous#ANONYMOUS_INFO}, if {@code null} is provided as
+	 *        principal.)
 	 */
 	public static DomainPrincipalInfo getPrincipalInfo(Principal principal) {
-		if (principal instanceof ExtensiblePrincipal) {
+		if (principal == null) {
+			return DomainApplicationAnonymous.ANONYMOUS_INFO;
+		} else if (principal instanceof ExtensiblePrincipal) {
 			@SuppressWarnings("unchecked")
 			ExtensiblePrincipal<? extends Principal> extensiblePrincipal = (ExtensiblePrincipal<? extends Principal>) principal;
 			DomainPrincipalInfoProvider provider = extensiblePrincipal.getExtendedInfo().get(INFO_PROVIDER,

--- a/element-connector/src/main/java/org/eclipse/californium/elements/EndpointContextMatcher.java
+++ b/element-connector/src/main/java/org/eclipse/californium/elements/EndpointContextMatcher.java
@@ -27,13 +27,6 @@ package org.eclipse.californium.elements;
 public interface EndpointContextMatcher extends EndpointIdentityResolver {
 
 	/**
-	 * Return matcher name. Used for logging.
-	 * 
-	 * @return name of strategy.
-	 */
-	String getName();
-
-	/**
 	 * Check, if responses is related to the request.
 	 * 
 	 * @param requestContext endpoint context of request

--- a/element-connector/src/main/java/org/eclipse/californium/elements/EndpointIdentityResolver.java
+++ b/element-connector/src/main/java/org/eclipse/californium/elements/EndpointIdentityResolver.java
@@ -32,6 +32,7 @@ public interface EndpointIdentityResolver {
 	 * 
 	 * @param context endpoint context
 	 * @return endpoint identity object.
+	 * @throws IllegalArgumentException if context doesn't contain an identity
 	 */
 	Object getEndpointIdentity(EndpointContext context);
 

--- a/element-connector/src/main/java/org/eclipse/californium/elements/PrincipalAndAnonymousEndpointContextMatcher.java
+++ b/element-connector/src/main/java/org/eclipse/californium/elements/PrincipalAndAnonymousEndpointContextMatcher.java
@@ -1,0 +1,122 @@
+/********************************************************************************
+ * Copyright (c) 2025 Contributors to the Eclipse Foundation
+ * 
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ * 
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * https://www.eclipse.org/legal/epl-2.0, or the Eclipse Distribution License
+ * v1.0 which is available at
+ * https://www.eclipse.org/org/documents/edl-v10.php.
+ * 
+ * SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
+ ********************************************************************************/
+package org.eclipse.californium.elements;
+
+import java.security.Principal;
+
+import org.eclipse.californium.elements.auth.ExtensiblePrincipal;
+import org.eclipse.californium.elements.util.Bytes;
+
+/**
+ * Principal based endpoint context matcher.
+ * <p>
+ * Matches DTLS based on the used principal or the session ID, if the principal
+ * is anonymous. Requires unique and stable credentials.
+ * 
+ * @since 4.0
+ */
+public class PrincipalAndAnonymousEndpointContextMatcher implements EndpointContextMatcher {
+
+	public PrincipalAndAnonymousEndpointContextMatcher() {
+	}
+
+	@Override
+	public String getName() {
+		return "principal and anonymous correlation";
+	}
+
+	/**
+	 * Gets identity from endpoint context.
+	 * <p>
+	 * Use the {@link Principal} if available and not
+	 * {@link ExtensiblePrincipal#isAnonymous()}. Otherwise use the DTLS session
+	 * ID.
+	 * 
+	 * @param context endpoint context
+	 * @return identity, or {@code null}, if none is available.
+	 */
+	private Object getIdentity(EndpointContext context) {
+		Principal identity = context.getPeerIdentity();
+		if (identity instanceof ExtensiblePrincipal<?>) {
+			if (((ExtensiblePrincipal<?>) identity).isAnonymous()) {
+				// anonymous principals don't have an identity.
+				identity = null;
+			}
+		}
+		if (identity != null) {
+			return identity;
+		}
+		Bytes id = context.get(DtlsEndpointContext.KEY_SESSION_ID);
+		if (id != null && !id.isEmpty()) {
+			return id;
+		}
+		return null;
+	}
+
+	@Override
+	public Object getEndpointIdentity(EndpointContext context) {
+		Object identity = getIdentity(context);
+		if (identity == null) {
+			throw new IllegalArgumentException(
+					"Principal identity and session id are missing in provided endpoint context!");
+		}
+		return identity;
+	}
+
+	@Override
+	public boolean isResponseRelatedToRequest(EndpointContext requestContext, EndpointContext responseContext) {
+		return internalMatch(requestContext, responseContext);
+	}
+
+	@Override
+	public boolean isToBeSent(EndpointContext messageContext, EndpointContext connectorContext) {
+		if (null == connectorContext) {
+			return true;
+		}
+		return internalMatch(messageContext, connectorContext);
+	}
+
+	private final boolean internalMatch(EndpointContext requestedContext, EndpointContext availableContext) {
+
+		Object identity = getIdentity(requestedContext);
+		if (identity != null) {
+			return identity.equals(getIdentity(availableContext));
+		}
+		String cipher = requestedContext.getString(DtlsEndpointContext.KEY_CIPHER);
+		if (cipher != null) {
+			if (!cipher.equals(availableContext.getString(DtlsEndpointContext.KEY_CIPHER))) {
+				return false;
+			}
+		}
+		return true;
+	}
+
+	@Override
+	public String toRelevantState(EndpointContext context) {
+		if (context == null) {
+			return "n.a.";
+		} else {
+			StringBuilder builder = new StringBuilder();
+			builder.append("[");
+			builder.append(getIdentity(context));
+			String cipher = context.getString(DtlsEndpointContext.KEY_CIPHER);
+			if (cipher != null) {
+				builder.append(",").append(cipher);
+			}
+			builder.append("]");
+			return builder.toString();
+		}
+	}
+}

--- a/element-connector/src/main/java/org/eclipse/californium/elements/PrincipalEndpointContextMatcher.java
+++ b/element-connector/src/main/java/org/eclipse/californium/elements/PrincipalEndpointContextMatcher.java
@@ -19,8 +19,9 @@ import java.security.Principal;
 
 /**
  * Principal based endpoint context matcher.
- * 
- * Matches DTLS based on the used principal. Requires unique and stable credentials.
+ * <p>
+ * Matches DTLS based on the used principal. Requires unique and stable
+ * credentials.
  */
 public class PrincipalEndpointContextMatcher implements EndpointContextMatcher {
 
@@ -66,11 +67,13 @@ public class PrincipalEndpointContextMatcher implements EndpointContextMatcher {
 	}
 
 	private final boolean internalMatch(EndpointContext requestedContext, EndpointContext availableContext) {
-		if (requestedContext.getPeerIdentity() != null) {
-			if (availableContext.getPeerIdentity() == null) {
+		Principal identity = requestedContext.getPeerIdentity();
+		if (identity != null) {
+			Principal availableIdentity = availableContext.getPeerIdentity();
+			if (availableIdentity == null) {
 				return false;
 			}
-			if (!matchPrincipals(requestedContext.getPeerIdentity(), availableContext.getPeerIdentity())) {
+			if (!matchPrincipals(identity, availableIdentity)) {
 				return false;
 			}
 		}
@@ -102,7 +105,7 @@ public class PrincipalEndpointContextMatcher implements EndpointContextMatcher {
 
 	/**
 	 * Match principals.
-	 * 
+	 * <p>
 	 * Intended to be overwritten, when asymmetric principal implementations are
 	 * used, and {@link #equals(Object)} doesn't work.
 	 * 

--- a/element-connector/src/main/java/org/eclipse/californium/elements/auth/AbstractExtensiblePrincipal.java
+++ b/element-connector/src/main/java/org/eclipse/californium/elements/auth/AbstractExtensiblePrincipal.java
@@ -49,11 +49,13 @@ public abstract class AbstractExtensiblePrincipal<T extends Principal> implement
 		}
 	}
 
-	/**
-	 * {@inheritDoc}
-	 */
 	@Override
 	public final AdditionalInfo getExtendedInfo() {
 		return additionalInfo;
+	}
+
+	@Override
+	public boolean isAnonymous() {
+		return false;
 	}
 }

--- a/element-connector/src/main/java/org/eclipse/californium/elements/auth/ApplicationAuthorizer.java
+++ b/element-connector/src/main/java/org/eclipse/californium/elements/auth/ApplicationAuthorizer.java
@@ -1,0 +1,57 @@
+/********************************************************************************
+ * Copyright (c) 2025 Contributors to the Eclipse Foundation
+ * 
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ * 
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * https://www.eclipse.org/legal/epl-2.0, or the Eclipse Distribution License
+ * v1.0 which is available at
+ * https://www.eclipse.org/org/documents/edl-v10.php.
+ * 
+ * SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
+ ********************************************************************************/
+package org.eclipse.californium.elements.auth;
+
+import java.security.Principal;
+import java.util.concurrent.Future;
+
+import org.eclipse.californium.elements.EndpointContext;
+
+/**
+ * Application authorize.
+ * <p>
+ * Sets {@link Principal} from application layers. Used with
+ * {@code DtlsConfig.DTLS_APPLICATION_AUTHORIZATION} to authorize or reject
+ * anonymous clients.
+ * 
+ * @since 4.0
+ */
+public interface ApplicationAuthorizer {
+
+	/**
+	 * Authorize the associated connection with the {@link ApplicationPrincipal}
+	 * to prevent connection from being removed after in short time.
+	 * <p>
+	 * The Authorization may be processed asynchronous. A future request
+	 * therefore may still not contain the provided principal! Only if the
+	 * connection has not already a principal assigned, the provided one will be
+	 * assigned.
+	 * 
+	 * @param context endpoint context
+	 * @param principal anonymous principal
+	 * @return future with boolean result. Completes with {@code true}, if the
+	 *         principal was assigned, {@code false}, otherwise.
+	 */
+	Future<Boolean> authorize(EndpointContext context, ApplicationPrincipal principal);
+
+	/**
+	 * Reject authorization.
+	 * 
+	 * @param context endpoint context to reject authorization.
+	 * @return future completes with removing the connection.
+	 */
+	Future<Void> rejectAuthorization(EndpointContext context);
+
+}

--- a/element-connector/src/main/java/org/eclipse/californium/elements/auth/ApplicationPrincipal.java
+++ b/element-connector/src/main/java/org/eclipse/californium/elements/auth/ApplicationPrincipal.java
@@ -1,0 +1,106 @@
+/********************************************************************************
+ * Copyright (c) 2025 Contributors to the Eclipse Foundation
+ * 
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ * 
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * https://www.eclipse.org/legal/epl-2.0, or the Eclipse Distribution License
+ * v1.0 which is available at
+ * https://www.eclipse.org/org/documents/edl-v10.php.
+ * 
+ * SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
+ ********************************************************************************/
+package org.eclipse.californium.elements.auth;
+
+import java.util.Objects;
+
+/**
+ * Application level principal.
+ * 
+ * @since 4.0
+ */
+public class ApplicationPrincipal extends AbstractExtensiblePrincipal<ApplicationPrincipal> {
+
+	/**
+	 * Anonymous principal.
+	 */
+	public static final ApplicationPrincipal ANONYMOUS = new ApplicationPrincipal("anonymous", true);
+
+	/**
+	 * Principal's name.
+	 */
+	private final String name;
+
+	/**
+	 * Mark for anonymous principals.
+	 */
+	private final boolean anonymous;
+
+	/**
+	 * Creates an application principal.
+	 * 
+	 * @param name name of principal
+	 * @param anonymous {@code true} for anonymous principal.
+	 */
+	public ApplicationPrincipal(String name, boolean anonymous) {
+		this.name = name;
+		this.anonymous = anonymous;
+	}
+
+	/**
+	 * Creates an application principal.
+	 * 
+	 * @param name name
+	 * @param anonymous {@code true} for anonymous principal.
+	 * @param additionalInformation additional information
+	 */
+	private ApplicationPrincipal(String name, boolean anonymous, AdditionalInfo additionalInformation) {
+		super(additionalInformation);
+		this.name = name;
+		this.anonymous = anonymous;
+	}
+
+	@Override
+	public ApplicationPrincipal amend(AdditionalInfo additionalInfo) {
+		return new ApplicationPrincipal(name, anonymous, additionalInfo);
+	}
+
+	@Override
+	public String getName() {
+		return name;
+	}
+
+	@Override
+	public String toString() {
+		return "Application Prinicpal [" + name + "]";
+	}
+
+	@Override
+	public int hashCode() {
+		return name.hashCode();
+	}
+
+	@Override
+	public boolean equals(Object obj) {
+		if (this == obj) {
+			return true;
+		} else if (obj == null) {
+			return false;
+		} else if (getClass() != obj.getClass()) {
+			return false;
+		}
+		ApplicationPrincipal other = (ApplicationPrincipal) obj;
+		if (anonymous != other.anonymous) {
+			return false;
+		}
+		return Objects.equals(name, other.name);
+	}
+
+	@Override
+	public boolean isAnonymous() {
+		return anonymous;
+	}
+
+}

--- a/element-connector/src/main/java/org/eclipse/californium/elements/auth/ExtensiblePrincipal.java
+++ b/element-connector/src/main/java/org/eclipse/californium/elements/auth/ExtensiblePrincipal.java
@@ -45,4 +45,14 @@ public interface ExtensiblePrincipal<T extends Principal> extends Principal {
 	 */
 	AdditionalInfo getExtendedInfo();
 
+	/**
+	 * Checks, if principal is anonymous.
+	 * <p>
+	 * Anonymous principals are not used as identities.
+	 * 
+	 * @return {@code true}, if principal represents an anonymous,
+	 *         {@code false}, otherwise.
+	 * @since 4.0
+	 */
+	boolean isAnonymous();
 }

--- a/element-connector/src/main/java/org/eclipse/californium/elements/auth/ExtensiblePrincipal.java
+++ b/element-connector/src/main/java/org/eclipse/californium/elements/auth/ExtensiblePrincipal.java
@@ -14,7 +14,6 @@
  *    Bosch Software Innovations GmbH - initial creation
  *******************************************************************************/
 
-
 package org.eclipse.californium.elements.auth;
 
 import java.security.Principal;
@@ -27,10 +26,11 @@ import java.security.Principal;
 public interface ExtensiblePrincipal<T extends Principal> extends Principal {
 
 	/**
-	 * Creates a shallow copy of this principal which contains additional information.
+	 * Creates a shallow copy of this principal which contains additional
+	 * information.
 	 * <p>
-	 * The additional information can be retrieved from the returned copy using the
-	 * {@link #getExtendedInfo()} method.
+	 * The additional information can be retrieved from the returned copy using
+	 * the {@link #getExtendedInfo()} method.
 	 * 
 	 * @param additionalInfo The additional information.
 	 * @return The copy.
@@ -44,4 +44,5 @@ public interface ExtensiblePrincipal<T extends Principal> extends Principal {
 	 *         The map will be empty if no additional information is available.
 	 */
 	AdditionalInfo getExtendedInfo();
+
 }

--- a/element-connector/src/main/java/org/eclipse/californium/elements/auth/PreSharedKeyIdentity.java
+++ b/element-connector/src/main/java/org/eclipse/californium/elements/auth/PreSharedKeyIdentity.java
@@ -46,11 +46,12 @@ public final class PreSharedKeyIdentity extends AbstractExtensiblePrincipal<PreS
 	 * Creates a new instance for an identity scoped to a virtual host.
 	 * 
 	 * @param virtualHost The virtual host name that the identity is scoped to.
-	 *                    The host name will be converted to lower case.
+	 *            The host name will be converted to lower case.
 	 * @param identity the identity.
 	 * @throws NullPointerException if the identity is {@code null}
 	 * @throws IllegalArgumentException if virtual host is not a valid host name
-	 *             as per <a href="https://tools.ietf.org/html/rfc1123" target="_blank">RFC 1123</a>.
+	 *             as per <a href="https://tools.ietf.org/html/rfc1123" target=
+	 *             "_blank">RFC 1123</a>.
 	 */
 	public PreSharedKeyIdentity(String virtualHost, String identity) {
 		this(true, virtualHost, identity, null);
@@ -66,10 +67,11 @@ public final class PreSharedKeyIdentity extends AbstractExtensiblePrincipal<PreS
 	 * @param additionalInformation Additional information for this principal.
 	 * @throws NullPointerException if the identity is {@code null}
 	 * @throws IllegalArgumentException if virtual host is not a valid host name
-	 *             as per <a href="https://tools.ietf.org/html/rfc1123" target="_blank">RFC
-	 *             1123</a>.
+	 *             as per <a href="https://tools.ietf.org/html/rfc1123" target=
+	 *             "_blank">RFC 1123</a>.
 	 */
-	private PreSharedKeyIdentity(boolean sni, String virtualHost, String identity, AdditionalInfo additionalInformation) {
+	private PreSharedKeyIdentity(boolean sni, String virtualHost, String identity,
+			AdditionalInfo additionalInformation) {
 		super(additionalInformation);
 		if (identity == null) {
 			throw new NullPointerException("Identity must not be null");
@@ -99,7 +101,8 @@ public final class PreSharedKeyIdentity extends AbstractExtensiblePrincipal<PreS
 		}
 	}
 
-	private PreSharedKeyIdentity(boolean scopedIdentity, String virtualHost, String identity, String name, AdditionalInfo additionalInfo) {
+	private PreSharedKeyIdentity(boolean scopedIdentity, String virtualHost, String identity, String name,
+			AdditionalInfo additionalInfo) {
 		super(additionalInfo);
 		this.scopedIdentity = scopedIdentity;
 		this.virtualHost = virtualHost;
@@ -160,7 +163,7 @@ public final class PreSharedKeyIdentity extends AbstractExtensiblePrincipal<PreS
 
 	/**
 	 * Gets a string representation of this principal.
-	 * 
+	 * <p>
 	 * Clients should not assume any particular format of the returned string
 	 * since it may change over time.
 	 * 
@@ -169,11 +172,9 @@ public final class PreSharedKeyIdentity extends AbstractExtensiblePrincipal<PreS
 	@Override
 	public String toString() {
 		if (scopedIdentity) {
-			return new StringBuilder("PreSharedKey Identity [").append("virtual host: ").append(virtualHost)
-					.append(", identity: ").append(identity).append("]").toString();
+			return "PreSharedKey Identity [virtual host: " + virtualHost + ", identity: " + identity + "]";
 		} else {
-			return new StringBuilder("PreSharedKey Identity [").append("identity: ").append(identity).append("]")
-					.toString();
+			return "PreSharedKey Identity [identity: " + identity + "]";
 		}
 	}
 
@@ -185,8 +186,9 @@ public final class PreSharedKeyIdentity extends AbstractExtensiblePrincipal<PreS
 	/**
 	 * Compares another object to this identity.
 	 * 
-	 * @return {@code true} if the other object is a {@code PreSharedKeyIdentity} and
-	 *         its name property has the same value as this instance.
+	 * @return {@code true} if the other object is a
+	 *         {@code PreSharedKeyIdentity} and its name property has the same
+	 *         value as this instance.
 	 */
 	@Override
 	public boolean equals(Object obj) {
@@ -200,4 +202,5 @@ public final class PreSharedKeyIdentity extends AbstractExtensiblePrincipal<PreS
 		PreSharedKeyIdentity other = (PreSharedKeyIdentity) obj;
 		return Objects.equals(name, other.name);
 	}
+
 }

--- a/element-connector/src/main/java/org/eclipse/californium/elements/auth/RawPublicKeyIdentity.java
+++ b/element-connector/src/main/java/org/eclipse/californium/elements/auth/RawPublicKeyIdentity.java
@@ -66,7 +66,8 @@ public class RawPublicKeyIdentity extends AbstractExtensiblePrincipal<RawPublicK
 	}
 
 	/**
-	 * Creates a new instance for a given ASN.1 subject public key info structure.
+	 * Creates a new instance for a given ASN.1 subject public key info
+	 * structure.
 	 * 
 	 * @param subjectInfo the ASN.1 encoded X.509 subject public key info.
 	 * @throws NullPointerException if the subject info is {@code null}
@@ -78,35 +79,40 @@ public class RawPublicKeyIdentity extends AbstractExtensiblePrincipal<RawPublicK
 	}
 
 	/**
-	 * Creates a new instance for a given ASN.1 subject public key info structure.
+	 * Creates a new instance for a given ASN.1 subject public key info
+	 * structure.
 	 * 
 	 * @param subjectInfo the ASN.1 encoded X.509 subject public key info.
 	 * @param keyAlgorithm the algorithm name to verify, that the subject public
 	 *            key uses this key algorithm, or to support currently not
-	 *            supported key algorithms for serialization/deserialization.
-	 *            If {@code null}, the key algorithm provided by the ASN.1
-	 *            DER encoded subject public key is used.
+	 *            supported key algorithms for serialization/deserialization. If
+	 *            {@code null}, the key algorithm provided by the ASN.1 DER
+	 *            encoded subject public key is used.
 	 * @throws NullPointerException if the subject info is {@code null}
-	 * @throws GeneralSecurityException if the JVM does not support the given key algorithm.
+	 * @throws GeneralSecurityException if the JVM does not support the given
+	 *             key algorithm.
 	 */
 	public RawPublicKeyIdentity(byte[] subjectInfo, String keyAlgorithm) throws GeneralSecurityException {
 		this(subjectInfo, keyAlgorithm, null);
 	}
 
 	/**
-	 * Creates a new instance for a given ASN.1 subject public key info structure.
+	 * Creates a new instance for a given ASN.1 subject public key info
+	 * structure.
 	 * 
 	 * @param subjectInfo the ASN.1 encoded X.509 subject public key info.
 	 * @param keyAlgorithm the algorithm name to verify, that the subject public
 	 *            key uses this key algorithm, or to support currently not
-	 *            supported key algorithms for serialization/deserialization.
-	 *            If {@code null}, the key algorithm provided by the ASN.1
-	 *            DER encoded subject public key is used.
+	 *            supported key algorithms for serialization/deserialization. If
+	 *            {@code null}, the key algorithm provided by the ASN.1 DER
+	 *            encoded subject public key is used.
 	 * @param additionalInformation Additional information for this principal.
 	 * @throws NullPointerException if the subject info is {@code null}
-	 * @throws GeneralSecurityException if the JVM does not support the given key algorithm.
+	 * @throws GeneralSecurityException if the JVM does not support the given
+	 *             key algorithm.
 	 */
-	private RawPublicKeyIdentity(byte[] subjectInfo, String keyAlgorithm, AdditionalInfo additionalInformation) throws GeneralSecurityException {
+	private RawPublicKeyIdentity(byte[] subjectInfo, String keyAlgorithm, AdditionalInfo additionalInformation)
+			throws GeneralSecurityException {
 		super(additionalInformation);
 		if (subjectInfo == null) {
 			throw new NullPointerException("SubjectPublicKeyInfo must not be null");
@@ -151,22 +157,21 @@ public class RawPublicKeyIdentity extends AbstractExtensiblePrincipal<RawPublicK
 		try {
 			MessageDigest md = MessageDigest.getInstance("SHA-256");
 			md.update(subjectPublicKeyInfo);
-			byte[] digest = md.digest();
-			String base64urlDigest = Base64.getUrlEncoder().withoutPadding().encodeToString(digest);
-			StringBuilder b = new StringBuilder("ni:///sha-256;").append(base64urlDigest);
-			niUri = b.toString();
+			niUri = "ni:///sha-256;" + Base64.getUrlEncoder().withoutPadding().encodeToString(md.digest());
 		} catch (NoSuchAlgorithmException e) {
-			// should not happen because SHA-256 is a mandatory message digest algorithm for any Java 7 VM
+			// should not happen because SHA-256 is a mandatory message digest
+			// algorithm for any Java 7 VM
 			// no Base64 encoding of InputStream is done
 		}
 	}
 
 	/**
 	 * Gets the <em>Named Information</em> URI representing this raw public key.
-	 * 
+	 * <p>
 	 * The URI is created using the SHA-256 hash algorithm on the key's
 	 * <em>SubjectPublicKeyInfo</em> as described in
-	 * <a href="https://tools.ietf.org/html/rfc6920#section-2" target="_blank">RFC 6920, section 2</a>.
+	 * <a href="https://tools.ietf.org/html/rfc6920#section-2" target=
+	 * "_blank">RFC 6920, section 2</a>.
 	 * 
 	 * @return the named information URI
 	 */
@@ -195,19 +200,20 @@ public class RawPublicKeyIdentity extends AbstractExtensiblePrincipal<RawPublicK
 
 	/**
 	 * Gets a string representation of this principal.
-	 * 
+	 * <p>
 	 * Clients should not assume any particular format of the returned string
 	 * since it may change over time.
-	 *  
+	 * 
 	 * @return the string representation
 	 */
 	@Override
 	public String toString() {
-		return new StringBuilder("RawPublicKey Identity [").append(niUri).append("]").toString();
+		return "RawPublicKey Identity [" + niUri + "]";
 	}
 
 	/**
-	 * Creates a hash code based on the key's ASN.1 encoded <em>SubjectPublicKeyInfo</em>.
+	 * Creates a hash code based on the key's ASN.1 encoded
+	 * <em>SubjectPublicKeyInfo</em>.
 	 * 
 	 * @return the hash code
 	 */
@@ -219,8 +225,9 @@ public class RawPublicKeyIdentity extends AbstractExtensiblePrincipal<RawPublicK
 	/**
 	 * Checks if this instance is equal to another object.
 	 * 
-	 * @return {@code true}, if the other object is a {@code RawPublicKeyIdentity}
-	 *           and has the same <em>SubjectPublicKeyInfo</em> as this instance
+	 * @return {@code true}, if the other object is a
+	 *         {@code RawPublicKeyIdentity} and has the same
+	 *         <em>SubjectPublicKeyInfo</em> as this instance
 	 */
 	@Override
 	public boolean equals(Object obj) {

--- a/element-connector/src/main/java/org/eclipse/californium/elements/auth/X509CertPath.java
+++ b/element-connector/src/main/java/org/eclipse/californium/elements/auth/X509CertPath.java
@@ -231,7 +231,7 @@ public class X509CertPath extends AbstractExtensiblePrincipal<X509CertPath> {
 
 	/**
 	 * Gets a string representation of this principal.
-	 * 
+	 * <p>
 	 * Clients should not assume any particular format of the returned string
 	 * since it may change over time.
 	 * 

--- a/element-connector/src/main/java/org/eclipse/californium/elements/exception/MissingApplicationAuthorizationException.java
+++ b/element-connector/src/main/java/org/eclipse/californium/elements/exception/MissingApplicationAuthorizationException.java
@@ -1,0 +1,48 @@
+/********************************************************************************
+ * Copyright (c) 2025 Contributors to the Eclipse Foundation
+ * 
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ * 
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * https://www.eclipse.org/legal/epl-2.0, or the Eclipse Distribution License
+ * v1.0 which is available at
+ * https://www.eclipse.org/org/documents/edl-v10.php.
+ * 
+ * SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
+ ********************************************************************************/
+package org.eclipse.californium.elements.exception;
+
+/**
+ * This class indicates missing application authorization for anonymous clients.
+ * 
+ * @since 4.0
+ */
+public class MissingApplicationAuthorizationException extends Exception {
+
+	private static final long serialVersionUID = 9209664901497784712L;
+
+	private final boolean rejected;
+
+	/**
+	 * Creates missing application authorization exception.
+	 * 
+	 * @param rejected {@code true}, if application rejected the authorization,
+	 *            {@code false}, if the authorization timed out.
+	 */
+	public MissingApplicationAuthorizationException(boolean rejected) {
+		super(rejected ? "rejected application authorization!" : "missing application authorization!");
+		this.rejected = rejected;
+	}
+
+	/**
+	 * Checks the cause of the missing application authorization
+	 * 
+	 * @return {@code true}, if application rejected the authorization,
+	 *         {@code false}, if the authorization timed out.
+	 */
+	public boolean isRejected() {
+		return rejected;
+	}
+}

--- a/element-connector/src/test/java/org/eclipse/californium/elements/PrincipalAndAnonymousEndpointContextMatcherTest.java
+++ b/element-connector/src/test/java/org/eclipse/californium/elements/PrincipalAndAnonymousEndpointContextMatcherTest.java
@@ -1,0 +1,117 @@
+/********************************************************************************
+ * Copyright (c) 2025 Contributors to the Eclipse Foundation
+ * 
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ * 
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * https://www.eclipse.org/legal/epl-2.0, or the Eclipse Distribution License
+ * v1.0 which is available at
+ * https://www.eclipse.org/org/documents/edl-v10.php.
+ * 
+ * SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
+ ********************************************************************************/
+package org.eclipse.californium.elements;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+
+import java.net.InetSocketAddress;
+import java.security.Principal;
+
+import org.eclipse.californium.elements.auth.ApplicationPrincipal;
+import org.eclipse.californium.elements.util.Bytes;
+import org.junit.Before;
+import org.junit.Test;
+
+public class PrincipalAndAnonymousEndpointContextMatcherTest {
+
+	private static final InetSocketAddress ADDRESS = new InetSocketAddress(0);
+	
+	private Principal principal1;
+	private Principal principal2;
+	private Principal principal3;
+	private Principal anonymous = ApplicationPrincipal.ANONYMOUS;
+	private EndpointContext connectionContext;
+	private EndpointContext messageContext;
+	private EndpointContext differentMessageContext;
+	private EndpointContext unsecureMessageContext;
+	private EndpointContext anonymousMessageContext;
+	private EndpointContext anonymousMessageContext2;
+	private EndpointContext anonymousConnectionContext;
+	private EndpointContextMatcher matcher;
+
+	@Before
+	public void setup() {
+		Bytes session = new Bytes("session".getBytes());
+		Bytes session2 = new Bytes("session2".getBytes());
+		principal1 = new TestPrincipal("P1");
+		principal2 = new TestPrincipal("P1"); // intended to have the same name as principal1
+		principal3 = new TestPrincipal("P3");
+
+		connectionContext = new DtlsEndpointContext(ADDRESS, null, principal1, session, 1, "CIPHER", 100);
+		anonymousConnectionContext = new DtlsEndpointContext(ADDRESS, null, anonymous, session2, 1, "CIPHER", 100);
+		messageContext = new AddressEndpointContext(ADDRESS, principal2);
+		differentMessageContext = new AddressEndpointContext(ADDRESS, principal3);
+		unsecureMessageContext = new AddressEndpointContext(ADDRESS, null);
+		anonymousMessageContext = new DtlsEndpointContext(ADDRESS, null, anonymous, session2, 1, "CIPHER", 100);
+		anonymousMessageContext2 = new DtlsEndpointContext(ADDRESS, null, null, session2, 1, "CIPHER", 100);
+		matcher = new PrincipalAndAnonymousEndpointContextMatcher();
+	}
+
+	@Test
+	public void testWithConnectionEndpointContext() {
+		assertThat(matcher.isToBeSent(messageContext, connectionContext), is(true));
+		assertThat(matcher.isToBeSent(differentMessageContext, connectionContext), is(false));
+		assertThat(matcher.isToBeSent(unsecureMessageContext, connectionContext), is(true));
+		assertThat(matcher.isToBeSent(anonymousMessageContext, connectionContext), is(false));
+		assertThat(matcher.isToBeSent(anonymousMessageContext2, connectionContext), is(false));
+	}
+
+	@Test
+	public void testWithAnonymousConnectionEndpointContext() {
+		assertThat(matcher.isToBeSent(messageContext, anonymousConnectionContext), is(false));
+		assertThat(matcher.isToBeSent(differentMessageContext, anonymousConnectionContext), is(false));
+		assertThat(matcher.isToBeSent(unsecureMessageContext, anonymousConnectionContext), is(true));
+		assertThat(matcher.isToBeSent(anonymousMessageContext, anonymousConnectionContext), is(true));
+		assertThat(matcher.isToBeSent(anonymousMessageContext2, anonymousConnectionContext), is(true));
+	}
+
+	@Test
+	public void testWithoutConnectionEndpointContext() {
+		assertThat(matcher.isToBeSent(messageContext, null), is(true));
+		assertThat(matcher.isToBeSent(differentMessageContext, null), is(true));
+		assertThat(matcher.isToBeSent(unsecureMessageContext, null), is(true));
+		assertThat(matcher.isToBeSent(anonymousMessageContext, null), is(true));
+		assertThat(matcher.isToBeSent(anonymousMessageContext2, null), is(true));
+	}
+
+	private static class TestPrincipal implements Principal {
+		private final String name;
+		public TestPrincipal(String name) {
+			this.name = name;
+		}
+		@Override
+		public String getName() {
+			return name;
+		}
+		
+		@Override
+		public int hashCode() {
+			return name.hashCode();
+		}
+		
+		@Override
+		public boolean equals(Object other) {
+			if (this == other) {
+				return true;
+			} else if (other == null || !(other instanceof Principal)) {
+				return false;
+			}
+			return name.equals(((Principal)other).getName());
+		}
+		
+	}
+
+}

--- a/element-connector/src/test/java/org/eclipse/californium/elements/UDPConnectorTest.java
+++ b/element-connector/src/test/java/org/eclipse/californium/elements/UDPConnectorTest.java
@@ -35,6 +35,7 @@ import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 
+import org.eclipse.californium.elements.rule.LoggingRule;
 import org.eclipse.californium.elements.rule.NetworkRule;
 import org.eclipse.californium.elements.rule.ThreadsRule;
 import org.eclipse.californium.elements.util.SimpleMessageCallback;
@@ -48,7 +49,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 public class UDPConnectorTest {
-	public static final Logger LOGGER = LoggerFactory.getLogger(UDPConnectorTest.class);
+	private static final Logger LOGGER = LoggerFactory.getLogger(UDPConnectorTest.class);
 
 	private static final long TIMEOUT_MILLIS = 1500;
 
@@ -57,6 +58,9 @@ public class UDPConnectorTest {
 
 	@Rule
 	public ThreadsRule cleanup = new ThreadsRule();
+
+	@Rule
+	public LoggingRule logging = new LoggingRule();
 
 	UDPConnector connector;
 	UDPConnector destination;
@@ -179,6 +183,7 @@ public class UDPConnectorTest {
 
 		SimpleMessageCallback callback = new SimpleMessageCallback(1, false);
 		RawData message = RawData.outbound(data, context, callback, false);
+		logging.setLoggingLevel("ERROR", UDPConnector.class);
 		connector.send(message);
 		assertThat(callback.await(TIMEOUT_MILLIS), is(true));
 		assertThat(callback.toString(), callback.getError(), is(notNullValue()));

--- a/element-connector/src/test/java/org/eclipse/californium/elements/rule/ThreadsRule.java
+++ b/element-connector/src/test/java/org/eclipse/californium/elements/rule/ThreadsRule.java
@@ -279,10 +279,10 @@ public class ThreadsRule implements TestRule {
 				} else {
 					LOGGER.info("Threads {} : {}{}", description, thread.getName(), mark);
 				}
-				if (LOGGER.isTraceEnabled()) {
+				if (LOGGER.isDebugEnabled()) {
 					StackTraceElement[] stackTrace = thread.getStackTrace();
 					for (StackTraceElement trace : stackTrace) {
-						LOGGER.trace("   {}", trace);
+						LOGGER.debug("   {}", trace);
 					}
 				}
 			} else {
@@ -351,7 +351,7 @@ public class ThreadsRule implements TestRule {
 	protected void shutdown() {
 		int hooks = cleanup.size();
 		if (hooks > 0) {
-			LOGGER.debug("{} shutdown hooks", hooks);
+			LOGGER.trace("{} shutdown hooks", hooks);
 			for (Runnable hook : cleanup) {
 				try {
 					hook.run();
@@ -363,7 +363,7 @@ public class ThreadsRule implements TestRule {
 		hooks = shutdown.size();
 		if (hooks > 0) {
 			try {
-				LOGGER.debug("{} shutdown executor services", hooks);
+				LOGGER.trace("{} shutdown executor services", hooks);
 				ExecutorsUtil.shutdownExecutorGracefully(1000, shutdown.toArray(new ExecutorService[hooks]));
 			} catch (RuntimeException ex) {
 				LOGGER.warn("shutdown failed!", ex);

--- a/element-connector/src/test/java/org/eclipse/californium/elements/util/Asn1DerDecoderTest.java
+++ b/element-connector/src/test/java/org/eclipse/californium/elements/util/Asn1DerDecoderTest.java
@@ -39,12 +39,15 @@ import org.eclipse.californium.elements.util.Asn1DerDecoder.Keys;
 import org.junit.BeforeClass;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * Verifies behavior of {@link Asn1DerDecoder}.
  */
 @Category(Small.class)
 public class Asn1DerDecoderTest {
+	private static final Logger LOGGER = LoggerFactory.getLogger(Asn1DerDecoderTest.class);
 
 	/**
 	 * DH subject public key, ASN.1 DER / Base64 encoded.
@@ -331,9 +334,9 @@ public class Asn1DerDecoderTest {
 			boolean valid = signature.verify(ghost);
 			if (valid) {
 				broken = true;
-				System.err.println(info + " is vulnerable for ECDSA R := 0, CVE-2022-21449!");
+				LOGGER.warn("{} is vulnerable for ECDSA R := 0, CVE-2022-21449!", info);
 			} else {
-				System.out.println(info + " is not vulnerable for ECDSA R := 0, CVE-2022-21449!");
+				LOGGER.info("{} is not vulnerable for ECDSA R := 0, CVE-2022-21449!", info);
 			}
 			try {
 				Asn1DerDecoder.checkEcDsaSignature(ghost, keys.getPublicKey());
@@ -358,14 +361,14 @@ public class Asn1DerDecoderTest {
 			try {
 				valid = signature.verify(ghost2);
 			} catch (SignatureException e) {
-				System.out.println(info + ", possible: " + e.getMessage());
+				LOGGER.info("{}, possible: {}", info, e.getMessage());
 				valid = false;
 			}
 			if (valid) {
 				broken = true;
-				System.err.println(info + " is vulnerable for ECDSA R := N, CVE-2022-21449!");
+				LOGGER.warn("{} is vulnerable for ECDSA R := N, CVE-2022-21449!", info);
 			} else {
-				System.out.println(info + " is not vulnerable for ECDSA R := N, CVE-2022-21449!");
+				LOGGER.info("{} is not vulnerable for ECDSA R := N, CVE-2022-21449!", info);
 			}
 			try {
 				Asn1DerDecoder.checkEcDsaSignature(ghost2, keys.getPublicKey());

--- a/element-connector/src/test/java/org/eclipse/californium/elements/util/PersistentComponentUtilTest.java
+++ b/element-connector/src/test/java/org/eclipse/californium/elements/util/PersistentComponentUtilTest.java
@@ -80,6 +80,7 @@ public class PersistentComponentUtilTest {
 		util.saveComponents(out, 1000);
 		ByteArrayInputStream in = new ByteArrayInputStream(out.toByteArray());
 		util = setup(connector2);
+		logging.setLoggingLevel("ERROR", PersistentComponentUtil.class);
 		util.loadComponents(in);
 		assertThat(connector1.data, is(nullValue()));
 		assertArrayEquals(connector2.mark, connector2.data);
@@ -92,6 +93,7 @@ public class PersistentComponentUtilTest {
 		util.saveComponents(out, 1000);
 		ByteArrayInputStream in = new ByteArrayInputStream(out.toByteArray());
 		util = setup(connector1);
+		logging.setLoggingLevel("ERROR", PersistentComponentUtil.class);
 		util.loadComponents(in);
 		assertArrayEquals(connector1.mark, connector1.data);
 		assertThat(connector2.data, is(nullValue()));
@@ -117,6 +119,7 @@ public class PersistentComponentUtilTest {
 		util.saveComponents(out, key, 1000);
 		ByteArrayInputStream in = new ByteArrayInputStream(out.toByteArray());
 		util = setup(connector2);
+		logging.setLoggingLevel("ERROR", PersistentComponentUtil.class);
 		util.loadComponents(in, key);
 		assertThat(connector1.data, is(nullValue()));
 		assertArrayEquals(connector2.mark, connector2.data);
@@ -130,6 +133,7 @@ public class PersistentComponentUtilTest {
 		util.saveComponents(out, key, 1000);
 		ByteArrayInputStream in = new ByteArrayInputStream(out.toByteArray());
 		util = setup(connector1);
+		logging.setLoggingLevel("ERROR", PersistentComponentUtil.class);
 		util.loadComponents(in, key);
 		assertArrayEquals(connector1.mark, connector1.data);
 		assertThat(connector2.data, is(nullValue()));
@@ -143,6 +147,7 @@ public class PersistentComponentUtilTest {
 		util.saveComponents(out, key, 1000);
 		ByteArrayInputStream in = new ByteArrayInputStream(out.toByteArray());
 		util = setup(connector1, connector3);
+		logging.setLoggingLevel("ERROR", PersistentComponentUtil.class);
 		util.loadComponents(in, key);
 		assertArrayEquals(connector1.mark, connector1.data);
 		assertThat(connector2.data, is(nullValue()));
@@ -182,7 +187,7 @@ public class PersistentComponentUtilTest {
 		ByteArrayOutputStream out = new ByteArrayOutputStream();
 		util.saveComponents(out, 1000);
 		ByteArrayInputStream in = new ByteArrayInputStream(out.toByteArray());
-		logging.setLoggingLevel("ERROR", PersistentComponentUtil.class);
+		logging.setLoggingLevel("ERROR", EncryptedStreamUtil.class);
 		util.loadComponents(in, key);
 		assertThat(connector1.data, is(nullValue()));
 		assertThat(connector2.data, is(nullValue()));

--- a/element-connector/src/test/java/org/eclipse/californium/elements/util/TestConditionTools.java
+++ b/element-connector/src/test/java/org/eclipse/californium/elements/util/TestConditionTools.java
@@ -17,6 +17,7 @@
 
 package org.eclipse.californium.elements.util;
 
+import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
 
 import java.util.concurrent.TimeUnit;
@@ -36,7 +37,7 @@ public final class TestConditionTools {
 
 	/**
 	 * Wait for condition to come {@code true}.
-	 * 
+	 * <p>
 	 * Used for none notifying conditions, which must be polled.
 	 * 
 	 * @param timeout timeout in {@code unit}
@@ -75,6 +76,24 @@ public final class TestConditionTools {
 	}
 
 	/**
+	 * Assert condition to come {@code true}.
+	 * <p>
+	 * Used for none notifying conditions, which must be polled.
+	 * 
+	 * @param timeout timeout in {@code unit}
+	 * @param interval interval of condition check in {@code unit}
+	 * @param unit time units for {@code timeout} and {@code interval}
+	 * @param check callback for condition test
+	 * @throws InterruptedException if the Thread is interrupted.
+	 * @throws AssertionError if assertion has failed
+	 * @since 4.0
+	 */
+	public static void assertCondition(long timeout, long interval, TimeUnit unit, TestCondition check)
+			throws InterruptedException {
+		assertThat(waitForCondition(timeout, interval, unit, check), is(true));
+	}
+
+	/**
 	 * Assert, that a statistic counter reaches the matcher's criterias within
 	 * the provided timeout.
 	 * 
@@ -84,6 +103,7 @@ public final class TestConditionTools {
 	 * @param timeout timeout to match
 	 * @param unit unit of timeout
 	 * @throws InterruptedException if wait is interrupted.
+	 * @throws AssertionError if assertion has failed
 	 * @see TestConditionTools#assertStatisticCounter(CounterStatisticManager,
 	 *      String, Matcher)
 	 */
@@ -113,6 +133,7 @@ public final class TestConditionTools {
 	 * @param timeout timeout to match
 	 * @param unit unit of timeout
 	 * @throws InterruptedException if wait is interrupted.
+	 * @throws AssertionError if assertion has failed
 	 * @see TestConditionTools#assertStatisticCounter(CounterStatisticManager,
 	 *      String, Matcher)
 	 * @since 2.4
@@ -138,6 +159,7 @@ public final class TestConditionTools {
 	 * @param manager statistic manager
 	 * @param name name of statistic.
 	 * @param matcher matcher for statistic counter value
+	 * @throws AssertionError if assertion has failed
 	 */
 	public static void assertStatisticCounter(CounterStatisticManager manager, String name,
 			Matcher<? super Long> matcher) {
@@ -151,6 +173,7 @@ public final class TestConditionTools {
 	 * @param manager statistic manager
 	 * @param name name of statistic.
 	 * @param matcher matcher for statistic counter value
+	 * @throws AssertionError if assertion has failed
 	 * @since 2.4
 	 */
 	public static void assertStatisticCounter(String message, CounterStatisticManager manager, String name,

--- a/scandium-core/README.md
+++ b/scandium-core/README.md
@@ -83,6 +83,30 @@ DTLSConnector connector = new DTLSConnector(builder.build());
 
 Starting with Californium 4.0 the support for anonymous clients is extended in order to match existing http authentication mechanisms. In those case the server authenticates itself using a certificate (RPK or x509) but the client stays anonymous in the DTLS handshake. It is the consider that such a client gets authorized by the application using an `ApplicationAuthorizer` by the means of the application. The new configuration parameter `DTLS.APPLICATION_AUTHORIZATION_TIMEOUT` enables to remove such anonymous clients after that timeout when the application doesn't authorize it. One simple implementation may be to support an CoAP2HTTP-cross-proxy, with a HTTP server using username/password or tokens to authorize the clients. The actual authentication, e.g. converting a custom coap-option into an http token header is then intended to be implemented in the proxy-application.
 
+The `ApplicationAuthorizer` is implemented by the `DTLSConnector`and is available at the `CoapEndpoint` and the `Exchange`.
+
+Specific `CoapResource` implementation:
+
+```
+@Override
+public void handlePOST(final CoapExchange exchange) {
+   // ... do some check, e.g. forward request using http
+   // authorized := result of authorization
+   if (exchange.getSourcePrincipal() == null) {
+      // anonymous client
+      ApplicationAuthorizer authorizer = getApplicationAuthorizer();
+      if (authorizer != null) {
+        if (authorized) {
+           authorizer.authorize(exchange.getSourceContext(),
+              ApplicationPrincipal.ANONYMOUS);
+        } else {
+           authorizer.rejectAuthorization(exchange.getSourceContext());
+        }
+     }
+   }
+}
+```
+
 ## Additional Parameters
 
 In order to limit the usage of some parameter, it is possible to provide them by the 

--- a/scandium-core/README.md
+++ b/scandium-core/README.md
@@ -81,6 +81,8 @@ builder.setCertificateVerifier(trust);
 DTLSConnector connector = new DTLSConnector(builder.build());
 ```
 
+Starting with Californium 4.0 the support for anonymous clients is extended in order to match existing http authentication mechanisms. In those case the server authenticates itself using a certificate (RPK or x509) but the client stays anonymous in the DTLS handshake. It is the consider that such a client gets authorized by the application using an `ApplicationAuthorizer` by the means of the application. The new configuration parameter `DTLS.APPLICATION_AUTHORIZATION_TIMEOUT` enables to remove such anonymous clients after that timeout when the application doesn't authorize it. One simple implementation may be to support an CoAP2HTTP-cross-proxy, with a HTTP server using username/password or tokens to authorize the clients. The actual authentication, e.g. converting a custom coap-option into an http token header is then intended to be implemented in the proxy-application.
+
 ## Additional Parameters
 
 In order to limit the usage of some parameter, it is possible to provide them by the 

--- a/scandium-core/src/main/java/org/eclipse/californium/scandium/ConnectionListener.java
+++ b/scandium-core/src/main/java/org/eclipse/californium/scandium/ConnectionListener.java
@@ -19,7 +19,7 @@ import org.eclipse.californium.scandium.dtls.Connection;
 
 /**
  * Listener for Connections life cycle.
- * 
+ * <p>
  * The callbacks are execution within the serial execution of the provided
  * connection. Therefore it's important to not block, otherwise the performance
  * will be downgraded. Though access to the connection must generally be done
@@ -58,9 +58,9 @@ public interface ConnectionListener {
 
 	/**
 	 * Callback, when connection gets removed from the connection store.
-	 * 
-	 * Note: since 3.0, the {@link Connection} is now always cleaned up before
-	 * it is used in this callback. {@link Connection#getPeerAddress()},
+	 * <p>
+	 * <b>Note:</b> since 3.0, the {@link Connection} is now always cleaned up
+	 * before it is used in this callback. {@link Connection#getPeerAddress()},
 	 * {@link Connection#getOngoingHandshake()}, and
 	 * {@link Connection#getDtlsContext()} (including the other variants) will
 	 * return {@code null}.

--- a/scandium-core/src/main/java/org/eclipse/californium/scandium/DTLSConnector.java
+++ b/scandium-core/src/main/java/org/eclipse/californium/scandium/DTLSConnector.java
@@ -1474,10 +1474,6 @@ public class DTLSConnector implements Connector, PersistentComponent, RecordLaye
 		return res;
 	}
 
-	public boolean restoreConnection(Connection connection) {
-		return connectionStore.restore(connection);
-	}
-
 	/**
 	 * Start to terminate connections related to the provided principals.
 	 * 

--- a/scandium-core/src/main/java/org/eclipse/californium/scandium/DatagramFilter.java
+++ b/scandium-core/src/main/java/org/eclipse/californium/scandium/DatagramFilter.java
@@ -76,4 +76,12 @@ public interface DatagramFilter {
 	 */
 	void onDrop(Record record);
 
+	/**
+	 * Called, when the application rejected to authorize an anonymous client.
+	 * 
+	 * @param connection rejected connection
+	 * @since 4.0
+	 */
+	void onApplicationAuthorizationRejected(Connection connection);
+
 }

--- a/scandium-core/src/main/java/org/eclipse/californium/scandium/DtlsHealth.java
+++ b/scandium-core/src/main/java/org/eclipse/californium/scandium/DtlsHealth.java
@@ -105,4 +105,13 @@ public interface DtlsHealth {
 	 */
 	void setPendingHandshakeJobs(int count);
 
+	/**
+	 * Report missing application authorization.
+	 * 
+	 * @param rejected {@code true}, if authorization was rejected,
+	 *            {@code false}, if the authorization is missing after a
+	 *            timeout.
+	 * @since 4.0
+	 */
+	void applicationAuthorizationRejected(boolean rejected);
 }

--- a/scandium-core/src/main/java/org/eclipse/californium/scandium/DtlsHealthLogger.java
+++ b/scandium-core/src/main/java/org/eclipse/californium/scandium/DtlsHealthLogger.java
@@ -60,6 +60,10 @@ public class DtlsHealthLogger extends CounterStatisticManager implements DtlsHea
 	private final SimpleCounterStatistic pendingOutgoing = new SimpleCounterStatistic("pending out jobs", align);
 	private final SimpleCounterStatistic pendingHandshakeJobs = new SimpleCounterStatistic("pending handshake jobs",
 			align);
+	private final SimpleCounterStatistic missingAuthorizations = new SimpleCounterStatistic(
+			"application missing authorizations", align);
+	private final SimpleCounterStatistic rejectedAuthorizations = new SimpleCounterStatistic(
+			"application rejected authorizations", align);
 
 	/**
 	 * Create passive dtls health logger.
@@ -91,6 +95,8 @@ public class DtlsHealthLogger extends CounterStatisticManager implements DtlsHea
 		add(pendingIncoming);
 		add(pendingOutgoing);
 		add(pendingHandshakeJobs);
+		add(missingAuthorizations);
+		add(rejectedAuthorizations);
 	}
 
 	@Override
@@ -116,6 +122,10 @@ public class DtlsHealthLogger extends CounterStatisticManager implements DtlsHea
 					log.append(eol).append(head).append(pendingIncoming);
 					log.append(eol).append(head).append(pendingOutgoing);
 					log.append(eol).append(head).append(pendingHandshakeJobs);
+					if (rejectedAuthorizations.isStarted() || missingAuthorizations.isStarted()) {
+						log.append(eol).append(head).append(missingAuthorizations);
+						log.append(eol).append(head).append(rejectedAuthorizations);
+					}
 					dump(head, log);
 					LOGGER.debug("{}", log);
 				}
@@ -126,6 +136,7 @@ public class DtlsHealthLogger extends CounterStatisticManager implements DtlsHea
 		}
 	}
 
+	@Override
 	public void dump(String tag, int maxConnections, int remainingCapacity) {
 		try {
 			if (isEnabled()) {
@@ -159,6 +170,10 @@ public class DtlsHealthLogger extends CounterStatisticManager implements DtlsHea
 					log.append(eol).append(head).append(pendingIncoming);
 					log.append(eol).append(head).append(pendingOutgoing);
 					log.append(eol).append(head).append(pendingHandshakeJobs);
+					if (rejectedAuthorizations.isStarted() || missingAuthorizations.isStarted()) {
+						log.append(eol).append(head).append(missingAuthorizations);
+						log.append(eol).append(head).append(rejectedAuthorizations);
+					}
 					dump(head, log);
 					LOGGER.debug("{}", log);
 				}
@@ -254,6 +269,15 @@ public class DtlsHealthLogger extends CounterStatisticManager implements DtlsHea
 	@Override
 	public void setPendingHandshakeJobs(int count) {
 		pendingHandshakeJobs.set(count);
+	}
+
+	@Override
+	public void applicationAuthorizationRejected(boolean rejected) {
+		if (rejected) {
+			rejectedAuthorizations.increment();
+		} else {
+			missingAuthorizations.increment();
+		}
 	}
 
 }

--- a/scandium-core/src/main/java/org/eclipse/californium/scandium/config/DtlsConfig.java
+++ b/scandium-core/src/main/java/org/eclipse/californium/scandium/config/DtlsConfig.java
@@ -22,6 +22,7 @@ import java.util.List;
 import java.util.concurrent.TimeUnit;
 
 import org.eclipse.californium.elements.DtlsEndpointContext;
+import org.eclipse.californium.elements.auth.ApplicationAuthorizer;
 import org.eclipse.californium.elements.config.BasicListDefinition;
 import org.eclipse.californium.elements.config.BooleanDefinition;
 import org.eclipse.californium.elements.config.CertificateAuthenticationMode;
@@ -80,11 +81,12 @@ public final class DtlsConfig {
 
 	/**
 	 * DTLS secure renegotiation.
-	 * 
+	 * <p>
 	 * Californium doesn't support renegotiation at all, but RFC5746 requests to
 	 * update to a minimal version of RFC 5746.
 	 * 
-	 * @see <a href="https://tools.ietf.org/html/rfc5746" target="_blank" >RFC 5746</a>
+	 * @see <a href="https://tools.ietf.org/html/rfc5746" target="_blank" >RFC
+	 *      5746</a>
 	 * 
 	 * @since 3.8
 	 */
@@ -261,7 +263,7 @@ public final class DtlsConfig {
 
 	/**
 	 * DTLS session timeout. Currently not supported!
-	 * 
+	 * <p>
 	 * Californium uses {@link #DTLS_MAX_CONNECTIONS} and
 	 * {@link #DTLS_STALE_CONNECTION_THRESHOLD} in order to keep session as
 	 * along as the resources are not required for fresh connections.
@@ -270,7 +272,7 @@ public final class DtlsConfig {
 			"DTLS session timeout. Currently not supported.", 1L, TimeUnit.HOURS);
 	/**
 	 * DTLS auto handshake timeout.
-	 * 
+	 * <p>
 	 * After that period without exchanged messages, new messages will initiate
 	 * a handshake. If possible a resumption/abbreviated handshake is used. Must
 	 * not be used with {@link DtlsRole#SERVER_ONLY}. {@code 30s} is a common
@@ -299,8 +301,9 @@ public final class DtlsConfig {
 	 * </ul>
 	 */
 	public static final IntegerDefinition DTLS_CONNECTION_ID_LENGTH = new IntegerDefinition(
-			MODULE + "CONNECTION_ID_LENGTH",
-			"DTLS connection ID length. <blank> default, -1 disables, 0 enables support without active use of CID.", 6, -1);
+			MODULE + "CONNECTION_ID_LENGTH", "DTLS connection ID length. <blank> default, -1 disables, "
+					+ "0 enables support without active use of CID.",
+			6, -1);
 
 	/**
 	 * If {@link #DTLS_CONNECTION_ID_LENGTH} enables the use of a connection id,
@@ -341,13 +344,13 @@ public final class DtlsConfig {
 	/**
 	 * Specify the additional initial DTLS retransmission timeout, when the
 	 * other peer is expected to perform ECC calculations.
-	 * 
+	 * <p>
 	 * ECC calculations may be time intensive, especially for smaller
 	 * micro-controllers without ecc-hardware support. The additional timeout
 	 * prevents Californium from resending a flight too early. The extra time is
 	 * used for the DTLS-client, if a ECDSA or ECDHE cipher suite is proposed,
 	 * and for the DTLS-server, if a ECDSA or ECDHE cipher suite is selected.
-	 * 
+	 * <p>
 	 * This timeout is added to {@link #DTLS_RETRANSMISSION_TIMEOUT} and on each
 	 * retransmission, the resulting time is doubled.
 	 */
@@ -363,27 +366,27 @@ public final class DtlsConfig {
 	/**
 	 * Specify the number of DTLS retransmissions before the attempt to transmit
 	 * a flight in back-off mode.
-	 * 
+	 * <p>
 	 * <a href="https://tools.ietf.org/html/rfc6347#page-12" target= "_blank">
 	 * RFC 6347, Section 4.1.1.1, Page 12</a>
-	 * 
+	 * <p>
 	 * In back-off mode, UDP datagrams of maximum 512 bytes or the negotiated
 	 * records size, if that is smaller, are used. Each handshake message is
 	 * placed in one dtls record, or more dtls records, if the handshake message
 	 * is too large and must be fragmented. Beside of the CCS and FINISH dtls
 	 * records, which send together in one UDP datagram, all other records are
 	 * send in separate datagrams.
-	 * 
+	 * <p>
 	 * The {@link #DTLS_USE_MULTI_HANDSHAKE_MESSAGE_RECORDS} and
 	 * {@link #DTLS_USE_MULTI_RECORD_MESSAGES} has precedence over the back-off
 	 * definition.
-	 * 
+	 * <p>
 	 * Value {@code 0}, to disable it, {@code null}, for default of
 	 * {@link #DTLS_MAX_RETRANSMISSIONS} / 2.
 	 */
 	public static final IntegerDefinition DTLS_RETRANSMISSION_BACKOFF = new IntegerDefinition(
-			MODULE + "RETRANSMISSION_BACKOFF",
-			"Number of flight-retransmissions before switching to backoff mode using single handshake messages in single record datagrams.",
+			MODULE + "RETRANSMISSION_BACKOFF", "Number of flight-retransmissions before switching to backoff mode "
+					+ "using single handshake messages in single record datagrams.",
 			null, 0);
 
 	/**
@@ -399,8 +402,8 @@ public final class DtlsConfig {
 	 * of next flight, not waiting for the last.
 	 */
 	public static final BooleanDefinition DTLS_USE_EARLY_STOP_RETRANSMISSION = new BooleanDefinition(
-			MODULE + "USE_EARLY_STOP_RETRANSMISSION",
-			"Stop retransmission on receiving the first message of the next flight, not waiting for the last message.",
+			MODULE + "USE_EARLY_STOP_RETRANSMISSION", "Stop retransmission on receiving the first message of the next "
+					+ "flight, not waiting for the last message.",
 			true);
 
 	/**
@@ -416,7 +419,7 @@ public final class DtlsConfig {
 	 * Specify the maximum fragment length.
 	 * 
 	 * @see <a href="https://tools.ietf.org/html/rfc6066#section-4" target=
-	 * "_blank">RFC 6066, Section 4</a>
+	 *      "_blank">RFC 6066, Section 4</a>
 	 */
 	public static final EnumDefinition<Length> DTLS_MAX_FRAGMENT_LENGTH = new EnumDefinition<>(
 			MODULE + "MAX_FRAGMENT_SIZE", "DTLS maximum fragment length (RFC 6066).", Length.values());
@@ -426,8 +429,8 @@ public final class DtlsConfig {
 	 */
 	public static final IntegerDefinition DTLS_MAX_FRAGMENTED_HANDSHAKE_MESSAGE_LENGTH = new IntegerDefinition(
 			MODULE + "MAX_FRAGMENTED_HANDSHAKE_MESSAGE_LENGTH",
-			"DTLS maximum length of reassembled fragmented handshake message.\n" +
-			"Must be large enough for used certificates.",
+			"DTLS maximum length of reassembled fragmented handshake message.\n"
+					+ "Must be large enough for used certificates.",
 			DEFAULT_MAX_FRAGMENTED_HANDSHAKE_MESSAGE_LENGTH, 64);
 
 	/**
@@ -440,7 +443,7 @@ public final class DtlsConfig {
 	 */
 	public static final BooleanDefinition DTLS_USE_MULTI_HANDSHAKE_MESSAGE_RECORDS = new BooleanDefinition(
 			MODULE + "USE_MULTI_HANDSHAKE_MESSAGE_RECORDS",
-			"Use multiple handshake messages in DTLS records.\nNot all libraries may have implemented this!");
+			"Use multiple handshake messages in DTLS records.\n" + "Not all libraries may have implemented this!");
 
 	/**
 	 * Specify the client's certificate authentication mode.
@@ -477,8 +480,8 @@ public final class DtlsConfig {
 
 	/**
 	 * Specify the MTU (Maximum Transmission Unit).
-	 * 
-	 * Note: Californium is only able to detect the MTU of local network
+	 * <p>
+	 * <b>Note:</b> Californium is only able to detect the MTU of local network
 	 * interfaces. For the transmission, the PMTU (Path Maximum Transmission
 	 * Unit) is required. Especially, if ip-tunnels are used, this value must be
 	 * provided in order to consider a smaller PMTU.
@@ -486,17 +489,19 @@ public final class DtlsConfig {
 	 * @see #DTLS_MAX_TRANSMISSION_UNIT_LIMIT
 	 */
 	public static final IntegerDefinition DTLS_MAX_TRANSMISSION_UNIT = new IntegerDefinition(
-			MODULE + "MAX_TRANSMISSION_UNIT", "DTLS MTU (Maximum Transmission Unit).\nMust be used, if the MTU of the local network doesn't apply, e.g. if ip-tunnels are used.", null, 64);
+			MODULE + "MAX_TRANSMISSION_UNIT", "DTLS MTU (Maximum Transmission Unit).\n"
+					+ "Must be used, if the MTU of the local network doesn't apply, " + "e.g. if ip-tunnels are used.",
+			null, 64);
 
 	/**
 	 * Specify a MTU (Maximum Transmission Unit) limit for (link local) auto
 	 * detection.
-	 * 
+	 * <p>
 	 * Limits maximum number of bytes sent in one transmission.
-	 *
-	 * Note: previous versions took the local link MTU without limits. That
-	 * results in possibly larger MTU, e.g. for localhost or some cloud nodes
-	 * using "jumbo frames". If a larger MTU is required to be detectable,
+	 * <p>
+	 * <b>Note:</b> previous versions took the local link MTU without limits.
+	 * That results in possibly larger MTU, e.g. for localhost or some cloud
+	 * nodes using "jumbo frames". If a larger MTU is required to be detectable,
 	 * please adjust this limit to the required value.
 	 * 
 	 * @see #DEFAULT_MAX_TRANSMISSION_UNIT_LIMIT
@@ -508,11 +513,11 @@ public final class DtlsConfig {
 
 	/**
 	 * Specify default handshake mode.
-	 * 
+	 * <p>
 	 * <b>Note:</b> if {@link #DTLS_ROLE} is {@link DtlsRole#SERVER_ONLY}, the
 	 * specified default handshake mode is ignored and replaced by
 	 * {@link DtlsEndpointContext#HANDSHAKE_MODE_NONE}.
-	 * 
+	 * <p>
 	 * Values are {@link DtlsEndpointContext#HANDSHAKE_MODE_NONE} or
 	 * {@link DtlsEndpointContext#HANDSHAKE_MODE_AUTO}.
 	 */
@@ -550,8 +555,8 @@ public final class DtlsConfig {
 	 */
 	public static final TimeDefinition DTLS_STALE_CONNECTION_THRESHOLD = new TimeDefinition(
 			MODULE + "STALE_CONNECTION_THRESHOLD",
-			"DTLS threshold for stale connections. Connections will only get removed for new ones, "+
-			"if at least for that threshold no messages are exchanged using that connection.",
+			"DTLS threshold for stale connections. Connections will only get removed for new ones, "
+					+ "if at least for that threshold no messages are exchanged using that connection.",
 			DEFAULT_STALE_CONNECTION_TRESHOLD_SECONDS, TimeUnit.SECONDS);
 
 	/**
@@ -561,8 +566,7 @@ public final class DtlsConfig {
 	 * @since 3.5
 	 */
 	public static final IntegerDefinition DTLS_MAX_PENDING_OUTBOUND_JOBS = new IntegerDefinition(
-			MODULE + "MAX_PENDING_OUTBOUND_JOBS",
-			"Maximum number of jobs for outbound DTLS messages.",
+			MODULE + "MAX_PENDING_OUTBOUND_JOBS", "Maximum number of jobs for outbound DTLS messages.",
 			DEFAULT_MAX_PENDING_OUTBOUND_JOBS, 64);
 
 	/**
@@ -572,8 +576,7 @@ public final class DtlsConfig {
 	 * @since 3.5
 	 */
 	public static final IntegerDefinition DTLS_MAX_PENDING_INBOUND_JOBS = new IntegerDefinition(
-			MODULE + "MAX_PENDING_INBOUND_JOBS",
-			"Maximum number of jobs for inbound DTLS messages.",
+			MODULE + "MAX_PENDING_INBOUND_JOBS", "Maximum number of jobs for inbound DTLS messages.",
 			DEFAULT_MAX_PENDING_INBOUND_JOBS, 64);
 	/**
 	 * Specify the number of pending handshake result jobs that can be queued
@@ -582,8 +585,7 @@ public final class DtlsConfig {
 	 * @since 3.5
 	 */
 	public static final IntegerDefinition DTLS_MAX_PENDING_HANDSHAKE_RESULT_JOBS = new IntegerDefinition(
-			MODULE + "MAX_PENDING_HANDSHAKE_RESULT_JOBS",
-			"Maximum number of jobs for DTLS handshake results.",
+			MODULE + "MAX_PENDING_HANDSHAKE_RESULT_JOBS", "Maximum number of jobs for DTLS handshake results.",
 			DEFAULT_MAX_PENDING_HANDSHAKE_RESULT_JOBS, 64);
 
 	/**
@@ -597,8 +599,8 @@ public final class DtlsConfig {
 	 */
 	public static final IntegerDefinition DTLS_MAX_DEFERRED_OUTBOUND_APPLICATION_MESSAGES = new IntegerDefinition(
 			MODULE + "MAX_DEFERRED_OUTBOUND_APPLICATION_MESSAGES",
-			"DTLS maximum deferred outbound application messages.",
-			DEFAULT_MAX_DEFERRED_OUTBOUND_APPLICATION_MESSAGES, 0);
+			"DTLS maximum deferred outbound application messages.", DEFAULT_MAX_DEFERRED_OUTBOUND_APPLICATION_MESSAGES,
+			0);
 	/**
 	 * Specify maximum size of deferred processed incoming records.
 	 * 
@@ -656,7 +658,7 @@ public final class DtlsConfig {
 	 * {@link org.eclipse.californium.elements.EndpointContext}.
 	 * 
 	 * @see <a href="https://tools.ietf.org/html/rfc6066#section-3" target=
-	 * "_blank">RFC 6066, Section 3</a>
+	 *      "_blank">RFC 6066, Section 3</a>
 	 */
 	public static final BooleanDefinition DTLS_USE_SERVER_NAME_INDICATION = new BooleanDefinition(
 			MODULE + "USE_SERVER_NAME_INDICATION", "DTLS use server name indication.", false);
@@ -665,7 +667,7 @@ public final class DtlsConfig {
 	 * Defines the usage of the "extend master secret" extension.
 	 * 
 	 * @see <a href="https://tools.ietf.org/html/rfc7627" target="_blank">RFC
-	 * 7627</a>
+	 *      7627</a>
 	 */
 	public static final EnumDefinition<ExtendedMasterSecretMode> DTLS_EXTENDED_MASTER_SECRET_MODE = new EnumDefinition<>(
 			MODULE + "EXTENDED_MASTER_SECRET_MODE", "DTLS extended master secret mode.",
@@ -695,7 +697,7 @@ public final class DtlsConfig {
 
 	/**
 	 * Use disabled window for anti replay filter.
-	 * 
+	 * <p>
 	 * Californium uses the "sliding receive window" approach mentioned in
 	 * <a href= "https://tools.ietf.org/html/rfc6347#section-4.1.2.6" target=
 	 * "_blank">RFC6347 4.1.2.6. Anti-Replay</a>. That causes trouble, if some
@@ -704,7 +706,7 @@ public final class DtlsConfig {
 	 * to discard such records, this values defines a "disabled window", that
 	 * allows record to pass the filter, even if the records are too old for the
 	 * current receive window.
-	 * 
+	 * <p>
 	 * The configured value will be subtracted from to lower receive window
 	 * boundary. A value of {@code -1} will set that calculated lower boundary
 	 * to {@code 0}. Messages between lower receive window boundary and that
@@ -733,7 +735,7 @@ public final class DtlsConfig {
 
 	/**
 	 * Only process newer records based on epoch/sequence_number.
-	 * 
+	 * <p>
 	 * Drop reorder records in order to protect from delay attacks, if no other
 	 * means, maybe on application level, are available.
 	 * 
@@ -741,14 +743,13 @@ public final class DtlsConfig {
 	 */
 	public static final BooleanDefinition DTLS_USE_NEWER_RECORD_FILTER = new BooleanDefinition(
 			MODULE + "USE_NEWER_FILTER",
-			"DTLS use newer record filter.\n" 
-					+ "Drop reordered records in order to protect from delay attacks,\n"
+			"DTLS use newer record filter.\n" + "Drop reordered records in order to protect from delay attacks,\n"
 					+ "if no other means, maybe on application level, are available.",
 			false);
 
 	/**
 	 * Use truncated certificate paths for client's certificate message.
-	 * 
+	 * <p>
 	 * Truncate certificate path according the received certificate authorities
 	 * in the {@link CertificateRequest} for the client's
 	 * {@link CertificateMessage}.
@@ -758,7 +759,7 @@ public final class DtlsConfig {
 
 	/**
 	 * Use truncated certificate paths for validation.
-	 * 
+	 * <p>
 	 * Truncate certificate path according the available trusted certificates
 	 * before validation.
 	 */
@@ -793,18 +794,18 @@ public final class DtlsConfig {
 	 */
 	public static final EnumListDefinition<CipherSuite> DTLS_PRESELECTED_CIPHER_SUITES = new EnumListDefinition<>(
 			MODULE + "PRESELECTED_CIPHER_SUITES",
-			"List of preselected DTLS cipher-suites.\n" +
-			"If not recommended cipher suites are intended to be used, switch off DTLS_RECOMMENDED_CIPHER_SUITES_ONLY.\n" +
-			"The supported cipher suites are evaluated at runtime and may differ from the ones when creating this properties file.",
+			"List of preselected DTLS cipher-suites.\n"
+					+ "If not recommended cipher suites are intended to be used, switch off DTLS_RECOMMENDED_CIPHER_SUITES_ONLY.\n"
+					+ "The supported cipher suites are evaluated at runtime and may differ from the ones when creating this properties file.",
 			CipherSuite.getCipherSuites(false, false));
 	/**
 	 * Select {@link CipherSuite}s.
 	 */
 	public static final EnumListDefinition<CipherSuite> DTLS_CIPHER_SUITES = new EnumListDefinition<>(
 			MODULE + "CIPHER_SUITES",
-			"List of DTLS cipher-suites.\n" +
-			"If not recommended cipher suites are intended to be used, switch off DTLS_RECOMMENDED_CIPHER_SUITES_ONLY.\n" +
-			"The supported cipher suites are evaluated at runtime and may differ from the ones when creating this properties file.",
+			"List of DTLS cipher-suites.\n"
+					+ "If not recommended cipher suites are intended to be used, switch off DTLS_RECOMMENDED_CIPHER_SUITES_ONLY.\n"
+					+ "The supported cipher suites are evaluated at runtime and may differ from the ones when creating this properties file.",
 			null, 1, CipherSuite.getCipherSuites(false, true));
 	/**
 	 * Select curves ({@link SupportedGroup}s).
@@ -823,8 +824,8 @@ public final class DtlsConfig {
 	 */
 	public static final EnumListDefinition<CertificateKeyAlgorithm> DTLS_CERTIFICATE_KEY_ALGORITHMS = new EnumListDefinition<>(
 			MODULE + "CERTIFICATE_KEY_ALGORITHMS",
-			"List of DTLS certificate key algorithms.\n" +
-			"On the client side used to select the default cipher-suites, on the server side to negotiate the client's certificate.",
+			"List of DTLS certificate key algorithms.\n"
+					+ "On the client side used to select the default cipher-suites, on the server side to negotiate the client's certificate.",
 			new CertificateKeyAlgorithm[] { CertificateKeyAlgorithm.EC, CipherSuite.CertificateKeyAlgorithm.RSA });
 
 	/**
@@ -846,13 +847,11 @@ public final class DtlsConfig {
 	 */
 	public static final BooleanDefinition DTLS_REMOVE_STALE_DOUBLE_PRINCIPALS = new BooleanDefinition(
 			MODULE + "REMOVE_STALE_DOUBLE_PRINCIPALS",
-			"Remove stale double principals.\n" + 
-			"Requires unique principals and a read-write-lock connection store.",
-			false);
+			"Remove stale double principals.\n" + "Requires unique principals.", false);
 
 	/**
 	 * Quiet time for DTLS MAC error filter.
-	 * 
+	 * <p>
 	 * To decrypt a message and calculate the MAC requires CPU. If a peer sends
 	 * many messages with a broken MAC (maybe because the message is sent by an
 	 * other peer with a spoofed source address), that may lower the overall
@@ -864,9 +863,9 @@ public final class DtlsConfig {
 	 * dropped before decryption in order to protect the CPU. This dropping last
 	 * for this quiet period and afterwards, the MAC error counter is reseted as
 	 * it is reseted, if no MAC error occurs for that time.
-	 * 
+	 * <p>
 	 * A value of {@code 0} disables the MAC error filter.
-	 * 
+	 * <p>
 	 * tn time n, c=n counter with value
 	 * 
 	 * <pre>
@@ -901,7 +900,7 @@ public final class DtlsConfig {
 
 	/**
 	 * Threshold for DTLS MAC error filter.
-	 * 
+	 * <p>
 	 * Maximum number of MAC errors, before all messages are dropped for the
 	 * {@link #DTLS_MAC_ERROR_FILTER_QUIET_TIME}. A value of {@code 0} disables
 	 * the MAC error filter.
@@ -915,11 +914,12 @@ public final class DtlsConfig {
 
 	/**
 	 * Specify the secure renegotiation mode.
-	 * 
+	 * <p>
 	 * Californium doesn't support renegotiation at all, but RFC5746 requests to
 	 * update to a minimal version of RFC 5746.
 	 * 
-	 * @see <a href="https://tools.ietf.org/html/rfc5746" target="_blank">RFC 5746</a>
+	 * @see <a href="https://tools.ietf.org/html/rfc5746" target="_blank">RFC
+	 *      5746</a>
 	 * 
 	 * @since 3.8
 	 */
@@ -932,12 +932,28 @@ public final class DtlsConfig {
 	/**
 	 * Support key material export.
 	 * 
-	 * @see <a href="https://tools.ietf.org/html/rfc5705" target="_blank">RFC 5705</a>
+	 * @see <a href="https://tools.ietf.org/html/rfc5705" target="_blank">RFC
+	 *      5705</a>
 	 * 
 	 * @since 3.10
 	 */
 	public static final BooleanDefinition DTLS_SUPPORT_KEY_MATERIAL_EXPORT = new BooleanDefinition(
 			MODULE + "SUPPORT_KEY_MATERIAL_EXPORT", "Support key material export according RFC5705.", false);
+
+	/**
+	 * Application authorization timeout for anonymous clients.
+	 * <p>
+	 * Used for certificate based handshakes without client certificates. If
+	 * enabled, connections without authenticated clients are removed after this
+	 * timeout, if not authorized using the {@link ApplicationAuthorizer}.
+	 * 
+	 * @see ApplicationAuthorizer
+	 * @since 4.0
+	 */
+	public static final TimeDefinition DTLS_APPLICATION_AUTHORIZATION_TIMEOUT = new TimeDefinition(
+			MODULE + "APPLICATION_AUTHORIZATION_TIMEOUT",
+			"Timeout for application authorization of anonymous clients.\n0s to switch off.",
+			0, TimeUnit.SECONDS);
 
 	public static final ModuleDefinitionsProvider DEFINITIONS = new ModuleDefinitionsProvider() {
 
@@ -1014,6 +1030,7 @@ public final class DtlsConfig {
 			config.set(DTLS_MAC_ERROR_FILTER_THRESHOLD, 0);
 			config.set(DTLS_SECURE_RENEGOTIATION, DEFAULT_SECURE_RENEGOTIATION);
 			config.set(DTLS_SUPPORT_KEY_MATERIAL_EXPORT, false);
+			config.set(DTLS_APPLICATION_AUTHORIZATION_TIMEOUT, 0, TimeUnit.SECONDS);
 
 			DefinitionUtils.verify(DtlsConfig.class, config);
 		}

--- a/scandium-core/src/main/java/org/eclipse/californium/scandium/dtls/CertificateVerificationResult.java
+++ b/scandium-core/src/main/java/org/eclipse/californium/scandium/dtls/CertificateVerificationResult.java
@@ -92,14 +92,11 @@ public final class CertificateVerificationResult extends HandshakeResult {
 	 * 
 	 * @param cid connection id
 	 * @param exception handshake exception.
-	 * @param customArgument custom argument. May be {@code null}. Passed to
-	 *            {@link ApplicationLevelInfoSupplier} by the
-	 *            {@link Handshaker}, if a
-	 *            {@link ApplicationLevelInfoSupplier} is available.
 	 * @throws NullPointerException if cid or exception is {@code null}.
+	 * @since 4.0 (removed customArgument)
 	 */
-	public CertificateVerificationResult(ConnectionId cid, HandshakeException exception, Object customArgument) {
-		super(cid, customArgument);
+	public CertificateVerificationResult(ConnectionId cid, HandshakeException exception) {
+		super(cid, null);
 		if (exception == null) {
 			throw new NullPointerException("exception must not be null!");
 		}

--- a/scandium-core/src/main/java/org/eclipse/californium/scandium/dtls/ConnectionId.java
+++ b/scandium-core/src/main/java/org/eclipse/californium/scandium/dtls/ConnectionId.java
@@ -28,7 +28,7 @@ public class ConnectionId extends Bytes {
 	public static final ConnectionId EMPTY = new ConnectionId(Bytes.EMPTY);
 
 	/**
-	 * Create connection id from bytes.
+	 * Creates connection id from bytes.
 	 * 
 	 * @param connectionId connectionId bytes
 	 * @throws NullPointerException if connectionId is {@code null}
@@ -73,8 +73,8 @@ public class ConnectionId extends Bytes {
 	}
 
 	/**
-	 * Check, if provided cid is used for records.
-	 * 
+	 * Checks, if provided cid is used for records.
+	 * <p>
 	 * Only none {@link ConnectionId#isEmpty()} cids are used for records.
 	 * 
 	 * @param cid cid
@@ -84,5 +84,24 @@ public class ConnectionId extends Bytes {
 	 */
 	public static boolean useConnectionId(ConnectionId cid) {
 		return cid != null && !cid.isEmpty();
+	}
+
+	/**
+	 * Creates connection id from bytes.
+	 * 
+	 * @param bytes bytes to create connection id
+	 * @return create connection id or the provided bytes, if that is already of
+	 *         type {@link ConnectionId}.
+	 * @since 4.0
+	 */
+	public static ConnectionId create(Bytes bytes) {
+		if (bytes == null || bytes.isEmpty()) {
+			return null;
+		}
+		if (bytes instanceof ConnectionId) {
+			return (ConnectionId) bytes;
+		} else {
+			return new ConnectionId(bytes.getBytes());
+		}
 	}
 }

--- a/scandium-core/src/main/java/org/eclipse/californium/scandium/dtls/HelloHandshakeMessage.java
+++ b/scandium-core/src/main/java/org/eclipse/californium/scandium/dtls/HelloHandshakeMessage.java
@@ -43,12 +43,11 @@ public abstract class HelloHandshakeMessage extends HandshakeMessage {
 	/** A generated random structure. */
 	protected final Random random;
 
-	/** The ID of a session the client wishes to use for this connection. */
+	/** The ID of a session of this connection. */
 	protected final SessionId sessionId;
 
 	/**
-	 * Clients MAY request extended functionality from servers by sending data
-	 * in the extensions field.
+	 * Client and server extensions.
 	 */
 	protected final HelloExtensions extensions = new HelloExtensions();
 
@@ -101,38 +100,41 @@ public abstract class HelloHandshakeMessage extends HandshakeMessage {
 		StringBuilder sb = new StringBuilder();
 		sb.append(super.toString(indent));
 		String indentation = StringUtil.indentation(indent + 1);
-		sb.append(indentation).append("Version: ").append(protocolVersion.getMajor()).append(", ").append(protocolVersion.getMinor()).append(StringUtil.lineSeparator());
+		sb.append(indentation).append("Version: ").append(protocolVersion.getMajor()).append(", ")
+				.append(protocolVersion.getMinor()).append(StringUtil.lineSeparator());
 		sb.append(indentation).append("Random:").append(StringUtil.lineSeparator());
 		sb.append(random.toString(indent + 2));
-		sb.append(indentation).append("Session ID Length: ").append(sessionId.length()).append(" bytes").append(StringUtil.lineSeparator());
-		if (sessionId.length() > 0) {
+		int len = sessionId.length();
+		sb.append(indentation).append("Session ID Length: ").append(len).append(" bytes")
+				.append(StringUtil.lineSeparator());
+		if (len > 0) {
 			sb.append(indentation).append("Session ID: ").append(sessionId).append(StringUtil.lineSeparator());
 		}
 		return sb.toString();
 	}
 
 	/**
-	 * Get protocol version.
+	 * Gets the protocol version.
 	 * 
-	 * @return protocol version.
+	 * @return the protocol version.
 	 */
 	public ProtocolVersion getProtocolVersion() {
 		return protocolVersion;
 	}
 
 	/**
-	 * Get client random
+	 * Gets the client random
 	 * 
-	 * @return client random
+	 * @return the client random
 	 */
 	public Random getRandom() {
 		return random;
 	}
 
 	/**
-	 * Get session id.
+	 * Gets the session id.
 	 * 
-	 * @return session id. May be empty.
+	 * @return the session id. May be empty.
 	 * @see #hasSessionId()
 	 */
 	public SessionId getSessionId() {
@@ -150,18 +152,18 @@ public abstract class HelloHandshakeMessage extends HandshakeMessage {
 	}
 
 	/**
-	 * Add hello extension.
+	 * Adds hello extension.
 	 * 
-	 * @param extension hello extension to add
+	 * @param extension the hello extension to add
 	 */
 	void addExtension(HelloExtension extension) {
 		extensions.addExtension(extension);
 	}
 
 	/**
-	 * Gets the client hello extensions the client has included in this message.
+	 * Gets the hello extensions the peer has included in this message.
 	 * 
-	 * @return The extensions. May be empty, if no extensions are used.
+	 * @return the extensions. May be empty, if no extensions are used.
 	 */
 	public HelloExtensions getExtensions() {
 		return extensions;
@@ -170,7 +172,7 @@ public abstract class HelloHandshakeMessage extends HandshakeMessage {
 	/**
 	 * Gets the supported point formats.
 	 * 
-	 * @return the client's supported point formats extension if available,
+	 * @return the supported point formats extension if available,
 	 *         otherwise {@code null}.
 	 */
 	public SupportedPointFormatsExtension getSupportedPointFormatsExtension() {

--- a/scandium-core/src/main/java/org/eclipse/californium/scandium/dtls/InMemoryConnectionStore.java
+++ b/scandium-core/src/main/java/org/eclipse/californium/scandium/dtls/InMemoryConnectionStore.java
@@ -321,7 +321,7 @@ public class InMemoryConnectionStore implements ConnectionStore {
 		connections.writeLock().lock();
 		try {
 			if (connections.update(connection.getConnectionId()) != null) {
-				connection.refreshAutoResumptionTime();
+				connection.updateLastMessageNanos();
 				if (newPeerAddress == null) {
 					LOGGER.debug("{}connection: {} updated usage!", tag, connection.getConnectionId());
 				} else if (!connection.equalsPeerAddress(newPeerAddress)) {

--- a/scandium-core/src/main/java/org/eclipse/californium/scandium/dtls/PskSecretResult.java
+++ b/scandium-core/src/main/java/org/eclipse/californium/scandium/dtls/PskSecretResult.java
@@ -64,12 +64,16 @@ public class PskSecretResult extends HandshakeResult {
 	 * @param pskIdentity PSK identity
 	 * @param secret secret, {@code null}, if generation failed. Algorithm must
 	 *            be "MAC" or "PSK".
-	 * @param customArgument custom argument. May be {@code null}. Passed to
+	 * @param customArgument custom argument. Must be {@code null}, if secret is
+	 *            {@code null}. May be {@code null}. Passed to
 	 *            {@link ApplicationLevelInfoSupplier} by the
-	 *            {@link Handshaker}, if a
-	 *            {@link ApplicationLevelInfoSupplier} is available.
-	 * @throws IllegalArgumentException if algorithm is neither "MAC" nor "PSK"
+	 *            {@link Handshaker}, if a {@link ApplicationLevelInfoSupplier}
+	 *            is available.
+	 * @throws IllegalArgumentException if algorithm is neither "MAC" nor "PSK".
+	 *             Or when a custom argument is provided without a secret
 	 * @throws NullPointerException if cid or pskIdentity is {@code null}
+	 * @since 4.0 (throws IllegalArgumentException, when a custom argument is
+	 *       provided without a secret)
 	 */
 	public PskSecretResult(ConnectionId cid, PskPublicInformation pskIdentity, SecretKey secret,
 			Object customArgument) {
@@ -84,6 +88,8 @@ public class PskSecretResult extends HandshakeResult {
 						"Secret must be either MAC for master secret, or PSK for secret key, but not " + algorithm
 								+ "!");
 			}
+		} else if (customArgument != null) {
+			throw new IllegalArgumentException("Custom argument must be null, if no secret is provided!");
 		}
 		this.pskIdentity = pskIdentity;
 		this.secret = secret;

--- a/scandium-core/src/main/java/org/eclipse/californium/scandium/dtls/x509/AsyncCertificateVerifier.java
+++ b/scandium-core/src/main/java/org/eclipse/californium/scandium/dtls/x509/AsyncCertificateVerifier.java
@@ -18,6 +18,7 @@ package org.eclipse.californium.scandium.dtls.x509;
 import java.net.InetSocketAddress;
 import java.security.PublicKey;
 import java.security.cert.CertPath;
+import java.security.cert.Certificate;
 import java.security.cert.X509Certificate;
 import java.util.List;
 import java.util.concurrent.ScheduledExecutorService;
@@ -37,16 +38,17 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 /**
- * Simple asynchronous test implementation of
- * {@link CertificateVerifier}.
+ * Simple asynchronous test implementation of {@link CertificateVerifier}.
  * <p>
  * Use {@code 0} or negative delays for test with synchronous blocking
  * behaviour. And positive delays for test with asynchronous none-blocking
  * behaviour.
  * 
- * @since 4.0 (Renamed AsyncNewAdvancedCertificateVerifier into AsyncCertificateVerifier)
+ * @since 4.0 (Renamed AsyncNewAdvancedCertificateVerifier into
+ *        AsyncCertificateVerifier)
  */
 public class AsyncCertificateVerifier extends StaticCertificateVerifier {
+
 	/**
 	 * @since 3.10
 	 */
@@ -55,7 +57,8 @@ public class AsyncCertificateVerifier extends StaticCertificateVerifier {
 	/**
 	 * Thread factory.
 	 */
-	private static final NamedThreadFactory THREAD_FACTORY = new DaemonThreadFactory("AsyncCertVerifier#", NamedThreadFactory.SCANDIUM_THREAD_GROUP);
+	private static final NamedThreadFactory THREAD_FACTORY = new DaemonThreadFactory("AsyncCertVerifier#",
+			NamedThreadFactory.SCANDIUM_THREAD_GROUP);
 	/**
 	 * Executor for asynchronous behaviour.
 	 */
@@ -73,8 +76,8 @@ public class AsyncCertificateVerifier extends StaticCertificateVerifier {
 	 */
 	private HandshakeResultHandler resultHandler;
 
-	public AsyncCertificateVerifier(X509Certificate[] trustedCertificates,
-			RawPublicKeyIdentity[] trustedRPKs, List<CertificateType> supportedCertificateTypes) {
+	public AsyncCertificateVerifier(X509Certificate[] trustedCertificates, RawPublicKeyIdentity[] trustedRPKs,
+			List<CertificateType> supportedCertificateTypes) {
 		super(trustedCertificates, trustedRPKs, supportedCertificateTypes);
 		executorService = ExecutorsUtil.newSingleThreadScheduledExecutor(THREAD_FACTORY); // $NON-NLS-1$
 	}
@@ -144,8 +147,7 @@ public class AsyncCertificateVerifier extends StaticCertificateVerifier {
 	}
 
 	private void verifyCertificateAsynchronous(ConnectionId cid, ServerNames serverName, InetSocketAddress remotePeer,
-			boolean clientUsage, boolean verifySubject, boolean truncateCertificatePath,
-			CertificateMessage message) {
+			boolean clientUsage, boolean verifySubject, boolean truncateCertificatePath, CertificateMessage message) {
 		CertificateVerificationResult result = super.verifyCertificate(cid, serverName, remotePeer, clientUsage,
 				verifySubject, truncateCertificatePath, message);
 		CertPath certPath = result.getCertificatePath();
@@ -174,6 +176,43 @@ public class AsyncCertificateVerifier extends StaticCertificateVerifier {
 
 	public static class Builder extends StaticCertificateVerifier.Builder {
 
+		@Override
+		public Builder setTrustedCertificates(Certificate... trustedCertificates) {
+			super.setTrustedCertificates(trustedCertificates);
+			return this;
+		}
+
+		@Override
+		public Builder setTrustAllCertificates() {
+			super.setTrustAllCertificates();
+			return this;
+		}
+
+		@Override
+		public Builder setTrustedRPKs(RawPublicKeyIdentity... trustedRPKs) {
+			super.setTrustedRPKs(trustedRPKs);
+			return this;
+		}
+
+		@Override
+		public Builder setTrustAllRPKs() {
+			super.setTrustAllRPKs();
+			return this;
+		}
+
+		@Override
+		public Builder setSupportedCertificateTypes(List<CertificateType> supportedCertificateTypes) {
+			super.setSupportedCertificateTypes(supportedCertificateTypes);
+			return this;
+		}
+
+		@Override
+		public Builder setUseEmptyAcceptedIssuers(boolean useEmptyAcceptedIssuers) {
+			super.setUseEmptyAcceptedIssuers(useEmptyAcceptedIssuers);
+			return this;
+		}
+
+		@Override
 		public AsyncCertificateVerifier build() {
 			return new AsyncCertificateVerifier(trustedCertificates, trustedRPKs, supportedCertificateTypes);
 		}

--- a/scandium-core/src/main/java/org/eclipse/californium/scandium/dtls/x509/StaticCertificateVerifier.java
+++ b/scandium-core/src/main/java/org/eclipse/californium/scandium/dtls/x509/StaticCertificateVerifier.java
@@ -247,7 +247,7 @@ public class StaticCertificateVerifier implements CertificateVerifier, Configura
 			}
 		} catch (HandshakeException e) {
 			LOGGER.debug("Certificate validation failed!", e);
-			return new CertificateVerificationResult(cid, e, null);
+			return new CertificateVerificationResult(cid, e);
 		}
 	}
 

--- a/scandium-core/src/test/java/org/eclipse/californium/scandium/ApplicationAuthorizationTest.java
+++ b/scandium-core/src/test/java/org/eclipse/californium/scandium/ApplicationAuthorizationTest.java
@@ -1,0 +1,307 @@
+/*******************************************************************************
+ * Copyright (c) 2018 - 2019 Bosch Software Innovations GmbH and others.
+ * 
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * and Eclipse Distribution License v1.0 which accompany this distribution.
+ * 
+ * The Eclipse Public License is available at
+ *    http://www.eclipse.org/legal/epl-v20.html
+ * and the Eclipse Distribution License is available at
+ *    http://www.eclipse.org/org/documents/edl-v10.html.
+ * 
+ * Contributors:
+ *    Achim Kraus (Bosch Software Innovations GmbH) - initial creation
+ *                                                    Based on the original test
+ *                                                    in DTLSConnectorTest.
+ *                                                    Updated to use ConnectorHelper
+ ******************************************************************************/
+package org.eclipse.californium.scandium;
+
+import static org.eclipse.californium.scandium.ConnectorHelper.SERVERNAME;
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.CoreMatchers.notNullValue;
+import static org.hamcrest.CoreMatchers.nullValue;
+import static org.hamcrest.MatcherAssert.assertThat;
+
+import java.io.IOException;
+import java.net.InetAddress;
+import java.net.InetSocketAddress;
+import java.security.GeneralSecurityException;
+import java.security.Principal;
+import java.util.Arrays;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+
+import org.eclipse.californium.elements.AddressEndpointContext;
+import org.eclipse.californium.elements.EndpointContext;
+import org.eclipse.californium.elements.RawData;
+import org.eclipse.californium.elements.auth.ApplicationPrincipal;
+import org.eclipse.californium.elements.category.Medium;
+import org.eclipse.californium.elements.config.CertificateAuthenticationMode;
+import org.eclipse.californium.elements.rule.LoggingRule;
+import org.eclipse.californium.elements.rule.TestNameLoggerRule;
+import org.eclipse.californium.elements.rule.TestTimeRule;
+import org.eclipse.californium.elements.rule.ThreadsRule;
+import org.eclipse.californium.elements.util.TestCondition;
+import org.eclipse.californium.elements.util.TestConditionTools;
+import org.eclipse.californium.scandium.ConnectorHelper.AlertCatcher;
+import org.eclipse.californium.scandium.config.DtlsConfig;
+import org.eclipse.californium.scandium.config.DtlsConnectorConfig;
+import org.eclipse.californium.scandium.dtls.DTLSSession;
+import org.eclipse.californium.scandium.dtls.DtlsTestTools;
+import org.eclipse.californium.scandium.dtls.x509.AsyncCertificateVerifier;
+import org.eclipse.californium.scandium.rule.DtlsNetworkRule;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+import org.junit.runners.Parameterized.Parameter;
+import org.junit.runners.Parameterized.Parameters;
+
+/**
+ * Verifies behavior of {@link DTLSConnector}.
+ * <p>
+ * Mainly contains integration test cases verifying the correct interaction
+ * between a client and a server during handshakes with and without SNI.
+ */
+@RunWith(Parameterized.class)
+@Category(Medium.class)
+public class ApplicationAuthorizationTest {
+
+	@ClassRule
+	public static DtlsNetworkRule network = new DtlsNetworkRule(DtlsNetworkRule.Mode.DIRECT,
+			DtlsNetworkRule.Mode.NATIVE);
+
+	@ClassRule
+	public static ThreadsRule cleanup = new ThreadsRule();
+
+	private static final int CLIENT_CONNECTION_STORE_CAPACITY = 5;
+
+	@Rule
+	public TestTimeRule time = new TestTimeRule();
+
+	@Rule
+	public TestNameLoggerRule names = new TestNameLoggerRule();
+	@Rule
+	public LoggingRule logging = new LoggingRule();
+
+	enum Mode {
+		NONE, AUTHORIZE, REJECT
+	}
+
+	@Parameter(0)
+	public Mode mode;
+
+	@Parameters(name = "mode {0}")
+	public static Iterable<Mode> setups() {
+		return Arrays.asList(Mode.values());
+	}
+
+	DtlsConnectorConfig.Builder serverBuilder;
+	ConnectorHelper serverHelper;
+
+	AsyncCertificateVerifier serverVerifier;
+
+	DtlsHealthLogger serverHealth;
+
+	DtlsConnectorConfig.Builder clientBuilder;
+	DTLSConnector client;
+	AlertCatcher clientAlertCatcher;
+	AsyncCertificateVerifier clientVerifier;
+	DtlsConnectorConfig.Builder clientConfigBuilder;
+
+	/**
+	 * Sets up the fixture.
+	 */
+	@Before
+	public void setUp() {
+
+		clientAlertCatcher = new AlertCatcher();
+
+		serverHelper = new ConnectorHelper(network);
+		serverBuilder = serverHelper.serverBuilder;
+		serverBuilder.set(DtlsConfig.DTLS_CLIENT_AUTHENTICATION_MODE, CertificateAuthenticationMode.NONE)
+		.set(DtlsConfig.DTLS_APPLICATION_AUTHORIZATION_TIMEOUT, 1, TimeUnit.SECONDS);
+
+		clientBuilder = DtlsConnectorConfig.builder(network.createClientTestConfig());
+	}
+
+	/**
+	 * Destroys the server and client.
+	 */
+	@After
+	public void cleanUp() {
+		if (serverHelper != null && serverHelper.server != null) {
+			assertThat(serverHelper.server.isRunning(), is(true));
+			try {
+				// wait until no pending jobs left
+				TestConditionTools.waitForCondition(6000, 100, TimeUnit.MILLISECONDS, new TestCondition() {
+
+					@Override
+					public boolean isFulFilled() throws IllegalStateException {
+						return !serverHelper.server.updateHealth();
+					}
+				});
+				TestConditionTools.assertStatisticCounter("jobs left", serverHealth, "pending in jobs", is(0L));
+				TestConditionTools.assertStatisticCounter("jobs left", serverHealth, "pending out jobs", is(0L));
+				TestConditionTools.assertStatisticCounter("jobs left", serverHealth, "pending handshake jobs", is(0L));
+			} catch (InterruptedException e) {
+			}
+		}
+		if (serverVerifier != null) {
+			serverVerifier.shutdown();
+			serverVerifier = null;
+		}
+		if (serverHelper != null) {
+			if (serverHelper.server != null) {
+				serverHelper.server.stop();
+				ConnectorHelper.assertReloadConnections("server", serverHelper.server);
+			}
+			serverHelper.destroyServer();
+			serverHelper = null;
+		}
+		if (clientVerifier != null) {
+			clientVerifier.shutdown();
+			clientVerifier = null;
+		}
+		if (client != null) {
+			client.stop();
+			ConnectorHelper.assertReloadConnections("client", client);
+			client.destroy();
+			client = null;
+		}
+	}
+
+	private void startServer() throws IOException, GeneralSecurityException {
+
+		DtlsConnectorConfig incompleteConfig = serverBuilder.getIncompleteConfig();
+
+		if (incompleteConfig.get(DtlsConfig.DTLS_CLIENT_AUTHENTICATION_MODE) != CertificateAuthenticationMode.NONE) {
+			if (incompleteConfig.getCertificateVerifier() == null) {
+				serverVerifier = AsyncCertificateVerifier.builder().setTrustAllCertificates().setTrustAllRPKs().build();
+				serverBuilder.setCertificateVerifier(serverVerifier);
+				serverVerifier.setDelay(DtlsTestTools.DEFAULT_HANDSHAKE_RESULT_DELAY_MILLIS);
+			}
+		}
+		serverHealth = new DtlsHealthLogger("server");
+		serverBuilder.setHealthHandler(serverHealth);
+		serverHelper.startServer();
+
+	}
+
+	private DTLSSession startClientRpk(String hostname) throws Exception {
+		clientVerifier = AsyncCertificateVerifier.builder().setTrustAllRPKs().build();
+		clientBuilder.setCertificateVerifier(clientVerifier);
+		return startClient(hostname);
+	}
+
+	private DTLSSession startClientX509(String hostname) throws Exception {
+		if (clientBuilder.getIncompleteConfig().getCertificateVerifier() == null) {
+			clientVerifier = AsyncCertificateVerifier.builder().setTrustAllCertificates()
+					.build();
+			clientBuilder.setCertificateVerifier(clientVerifier);
+		}
+		return startClient(hostname);
+	}
+
+	private DTLSSession startClient(String hostname) throws Exception {
+		InetSocketAddress clientEndpoint = new InetSocketAddress(InetAddress.getLoopbackAddress(), 0);
+		clientBuilder.setAddress(clientEndpoint).setLoggingTag("client").set(DtlsConfig.DTLS_RECEIVER_THREAD_COUNT, 1)
+				.set(DtlsConfig.DTLS_CONNECTOR_THREAD_COUNT, 1)
+				.set(DtlsConfig.DTLS_MAX_CONNECTIONS, CLIENT_CONNECTION_STORE_CAPACITY);
+
+		DtlsConnectorConfig clientConfig = clientBuilder.build();
+
+		client = serverHelper.createClient(clientConfig);
+		client.setAlertHandler(clientAlertCatcher);
+		RawData raw = RawData.outbound("Hello World".getBytes(),
+				new AddressEndpointContext(serverHelper.serverEndpoint, hostname, null), null, false);
+		serverHelper.givenAnEstablishedSession(client, raw, true);
+		final DTLSSession session = client.getSessionByAddress(serverHelper.serverEndpoint);
+		assertThat(session, is(notNullValue()));
+		return session;
+	}
+
+	@Test
+	public void testRpkHandshakeApplicationAuthorized() throws Exception {
+		startServer();
+		startClientRpk(null);
+		final EndpointContext endpointContext = serverHelper.serverRawDataProcessor.getClientEndpointContext();
+
+		// client's principal
+		Principal principal = endpointContext.getPeerIdentity();
+		assertThat(principal, is(nullValue()));
+
+		if (mode == Mode.AUTHORIZE) {
+			Future<Boolean> future = serverHelper.server.authorize(endpointContext, ApplicationPrincipal.ANONYMOUS);
+			assertThat(future.get(1000, TimeUnit.MILLISECONDS), is(true));
+			principal = serverHelper.getServersClientIdentity(endpointContext);
+			assertThat(principal, is(ApplicationPrincipal.ANONYMOUS));
+			// second authorization is rejected.
+			future = serverHelper.server.authorize(endpointContext, new ApplicationPrincipal("test", false));
+			assertThat(future.get(1000, TimeUnit.MILLISECONDS), is(false));
+			principal = serverHelper.getServersClientIdentity(endpointContext);
+			assertThat(principal, is(ApplicationPrincipal.ANONYMOUS));
+			
+		} else if (mode == Mode.REJECT) {
+			Future<Void> future = serverHelper.server.rejectAuthorization(endpointContext);
+			future.get(1000, TimeUnit.MILLISECONDS);
+			TestConditionTools.assertStatisticCounter(serverHealth, "application rejected authorizations", is(1L), 500,
+					TimeUnit.MILLISECONDS);
+		} else if (mode == Mode.NONE) {
+			Thread.sleep(2000);
+		}
+
+		// still available after recent handshake timeout
+		time.addTestTimeShift(CookieGenerator.COOKIE_LIFETIME_NANOS * 3, TimeUnit.NANOSECONDS);
+
+		serverHelper.server.cleanupRecentHandshakes(0);
+//		assertThat(serverHelper.server.cleanupRecentHandshakes(0), is(1));
+		if (mode == Mode.NONE) {
+			TestConditionTools.assertStatisticCounter(serverHealth, "application missing authorizations", is(1L), 500,
+					TimeUnit.MILLISECONDS);
+		}
+		serverHelper.getServerConnection(endpointContext, mode == Mode.AUTHORIZE);
+	}
+
+	@Test
+	public void testX509HandshakeApplicationAuthorized() throws Exception {
+		startServer();
+		startClientX509(SERVERNAME);
+		EndpointContext endpointContext = serverHelper.serverRawDataProcessor.getClientEndpointContext();
+
+		// client's principal
+		Principal principal = endpointContext.getPeerIdentity();
+		assertThat(principal, is(nullValue()));
+
+		if (mode == Mode.AUTHORIZE) {
+			Future<Boolean> future = serverHelper.server.authorize(endpointContext, ApplicationPrincipal.ANONYMOUS);
+			future.get(1000, TimeUnit.MILLISECONDS);
+			principal = serverHelper.getServersClientIdentity(endpointContext);
+			assertThat(principal, is(ApplicationPrincipal.ANONYMOUS));
+		} else if (mode == Mode.REJECT) {
+			Future<Void> future = serverHelper.server.rejectAuthorization(endpointContext);
+			future.get(1000, TimeUnit.MILLISECONDS);
+			TestConditionTools.assertStatisticCounter(serverHealth, "application rejected authorizations", is(1L), 500,
+					TimeUnit.MILLISECONDS);
+		} else if (mode == Mode.NONE) {
+			Thread.sleep(2000);
+		}
+
+		// still available after recent handshake timeout
+		time.addTestTimeShift(CookieGenerator.COOKIE_LIFETIME_NANOS * 3, TimeUnit.NANOSECONDS);
+
+		serverHelper.server.cleanupRecentHandshakes(0);
+//		assertThat(serverHelper.server.cleanupRecentHandshakes(0), is(1));
+		if (mode == Mode.NONE) {
+			TestConditionTools.assertStatisticCounter(serverHealth, "application missing authorizations", is(1L), 500,
+					TimeUnit.MILLISECONDS);
+		}
+		serverHelper.getServerConnection(endpointContext, mode == Mode.AUTHORIZE);
+	}
+}

--- a/scandium-core/src/test/java/org/eclipse/californium/scandium/ConnectorHelper.java
+++ b/scandium-core/src/test/java/org/eclipse/californium/scandium/ConnectorHelper.java
@@ -685,7 +685,13 @@ public class ConnectorHelper {
 			if (processor != null) {
 				RawData response = processor.process(raw);
 				if (response != null && connector != null) {
-					connector.send(response);
+					try {
+						connector.send(response);
+					} catch (IllegalStateException ex) {
+						if (connector.isRunning()) {
+							throw ex;
+						}
+					}
 				}
 			}
 		}

--- a/scandium-core/src/test/java/org/eclipse/californium/scandium/DTLSConnectorAdvancedTest.java
+++ b/scandium-core/src/test/java/org/eclipse/californium/scandium/DTLSConnectorAdvancedTest.java
@@ -389,7 +389,7 @@ public class DTLSConnectorAdvancedTest {
 		verifyHandshakeResponses = 1;
 		resumeHandshakeResponses = 1;
 
-		clientCertificateVerifier = (AsyncCertificateVerifier)AsyncCertificateVerifier.builder()
+		clientCertificateVerifier = AsyncCertificateVerifier.builder()
 				.setTrustedCertificates(DtlsTestTools.getTrustedCertificates())
 				.setTrustAllRPKs()
 				.build();

--- a/scandium-core/src/test/java/org/eclipse/californium/scandium/DTLSConnectorHandshakeTest.java
+++ b/scandium-core/src/test/java/org/eclipse/californium/scandium/DTLSConnectorHandshakeTest.java
@@ -457,7 +457,7 @@ public class DTLSConnectorHandshakeTest {
 		}
 		if (incompleteConfig.get(DtlsConfig.DTLS_CLIENT_AUTHENTICATION_MODE) != CertificateAuthenticationMode.NONE) {
 			if (incompleteConfig.getCertificateVerifier() == null) {
-				serverVerifier = (AsyncCertificateVerifier) AsyncCertificateVerifier.builder()
+				serverVerifier = AsyncCertificateVerifier.builder()
 						.setTrustAllCertificates().setTrustAllRPKs().build();
 				serverBuilder.setCertificateVerifier(serverVerifier);
 				serverVerifier.setDelay(DtlsTestTools.DEFAULT_HANDSHAKE_RESULT_DELAY_MILLIS);
@@ -480,7 +480,7 @@ public class DTLSConnectorHandshakeTest {
 	}
 
 	private DTLSSession startClientRpk(String hostname) throws Exception {
-		AsyncCertificateVerifier clientCertificateVerifier = (AsyncCertificateVerifier) AsyncCertificateVerifier
+		AsyncCertificateVerifier clientCertificateVerifier = AsyncCertificateVerifier
 				.builder().setTrustAllRPKs().build();
 		clientsCertificateVerifiers.add(clientCertificateVerifier);
 		clientBuilder.setCertificateVerifier(clientCertificateVerifier);
@@ -489,7 +489,7 @@ public class DTLSConnectorHandshakeTest {
 
 	private DTLSSession startClientX509(String hostname) throws Exception {
 		if (clientBuilder.getIncompleteConfig().getCertificateVerifier() == null) {
-			AsyncCertificateVerifier clientCertificateVerifier = (AsyncCertificateVerifier) AsyncCertificateVerifier
+			AsyncCertificateVerifier clientCertificateVerifier = AsyncCertificateVerifier
 					.builder().setTrustAllCertificates().build();
 			clientsCertificateVerifiers.add(clientCertificateVerifier);
 			clientBuilder.setCertificateVerifier(clientCertificateVerifier);
@@ -786,7 +786,7 @@ public class DTLSConnectorHandshakeTest {
 		serverBuilder.set(DtlsConfig.DTLS_USE_SERVER_NAME_INDICATION, true);
 		startServer();
 
-		AsyncCertificateVerifier clientCertificateVerifier = (AsyncCertificateVerifier) AsyncCertificateVerifier
+		AsyncCertificateVerifier clientCertificateVerifier = AsyncCertificateVerifier
 				.builder().setTrustAllCertificates().build();
 		clientsCertificateVerifiers.add(clientCertificateVerifier);
 		clientBuilder.set(DtlsConfig.DTLS_USE_SERVER_NAME_INDICATION, true)
@@ -820,7 +820,7 @@ public class DTLSConnectorHandshakeTest {
 		serverBuilder.set(DtlsConfig.DTLS_USE_SERVER_NAME_INDICATION, true);
 		startServer();
 
-		AsyncCertificateVerifier clientCertificateVerifier = (AsyncCertificateVerifier) AsyncCertificateVerifier
+		AsyncCertificateVerifier clientCertificateVerifier = AsyncCertificateVerifier
 				.builder().setTrustAllCertificates().build();
 		clientsCertificateVerifiers.add(clientCertificateVerifier);
 		clientBuilder.setCertificateVerifier(clientCertificateVerifier)
@@ -1119,7 +1119,7 @@ public class DTLSConnectorHandshakeTest {
 		serverBuilder.setAsList(DtlsConfig.DTLS_CERTIFICATE_KEY_ALGORITHMS, CertificateKeyAlgorithm.EC);
 		startServer();
 
-		AsyncCertificateVerifier clientCertificateVerifier = (AsyncCertificateVerifier) AsyncCertificateVerifier
+		AsyncCertificateVerifier clientCertificateVerifier = AsyncCertificateVerifier
 				.builder().setTrustAllCertificates().build();
 		clientsCertificateVerifiers.add(clientCertificateVerifier);
 
@@ -1154,7 +1154,7 @@ public class DTLSConnectorHandshakeTest {
 				.setCertificateIdentityProvider(new SingleCertificateProvider(DtlsTestTools.getPrivateKey(),
 						DtlsTestTools.getServerCertificateChain()));
 		startServer();
-		AsyncCertificateVerifier clientCertificateVerifier = (AsyncCertificateVerifier) AsyncCertificateVerifier
+		AsyncCertificateVerifier clientCertificateVerifier = AsyncCertificateVerifier
 				.builder().setTrustedCertificates(DtlsTestTools.getServerCertificateChain()[0]).build();
 		clientsCertificateVerifiers.add(clientCertificateVerifier);
 		clientBuilder.setCertificateVerifier(clientCertificateVerifier);
@@ -1755,7 +1755,7 @@ public class DTLSConnectorHandshakeTest {
 				.set(DtlsConfig.DTLS_CLIENT_AUTHENTICATION_MODE, CertificateAuthenticationMode.WANTED);
 		startServer();
 
-		AsyncCertificateVerifier clientCertificateVerifier = (AsyncCertificateVerifier) AsyncCertificateVerifier
+		AsyncCertificateVerifier clientCertificateVerifier = AsyncCertificateVerifier
 				.builder().setTrustAllRPKs().build();
 		clientsCertificateVerifiers.add(clientCertificateVerifier);
 
@@ -1797,7 +1797,7 @@ public class DTLSConnectorHandshakeTest {
 				.set(DtlsConfig.DTLS_CLIENT_AUTHENTICATION_MODE, CertificateAuthenticationMode.WANTED);
 		startServer();
 
-		AsyncCertificateVerifier clientCertificateVerifier = (AsyncCertificateVerifier) AsyncCertificateVerifier
+		AsyncCertificateVerifier clientCertificateVerifier = AsyncCertificateVerifier
 				.builder().setTrustAllRPKs().build();
 		clientsCertificateVerifiers.add(clientCertificateVerifier);
 
@@ -1839,7 +1839,7 @@ public class DTLSConnectorHandshakeTest {
 				.set(DtlsConfig.DTLS_CLIENT_AUTHENTICATION_MODE, CertificateAuthenticationMode.WANTED);
 		startServer();
 
-		AsyncCertificateVerifier clientCertificateVerifier = (AsyncCertificateVerifier) AsyncCertificateVerifier
+		AsyncCertificateVerifier clientCertificateVerifier = AsyncCertificateVerifier
 				.builder().setTrustAllRPKs().build();
 		clientsCertificateVerifiers.add(clientCertificateVerifier);
 
@@ -1875,7 +1875,7 @@ public class DTLSConnectorHandshakeTest {
 				.set(DtlsConfig.DTLS_CLIENT_AUTHENTICATION_MODE, CertificateAuthenticationMode.WANTED);
 		startServer();
 
-		AsyncCertificateVerifier clientCertificateVerifier = (AsyncCertificateVerifier) AsyncCertificateVerifier
+		AsyncCertificateVerifier clientCertificateVerifier = AsyncCertificateVerifier
 				.builder().setTrustAllRPKs().build();
 		clientsCertificateVerifiers.add(clientCertificateVerifier);
 
@@ -1908,7 +1908,7 @@ public class DTLSConnectorHandshakeTest {
 				new KeyManagerCertificateProvider(DtlsTestTools.getDtlsServerKeyManager(), CertificateType.X_509));
 		startServer();
 
-		AsyncCertificateVerifier clientCertificateVerifier = (AsyncCertificateVerifier) AsyncCertificateVerifier
+		AsyncCertificateVerifier clientCertificateVerifier = AsyncCertificateVerifier
 				.builder().setTrustAllCertificates().build();
 		clientsCertificateVerifiers.add(clientCertificateVerifier);
 
@@ -1946,7 +1946,7 @@ public class DTLSConnectorHandshakeTest {
 								CertificateType.X_509));
 		startServer();
 
-		AsyncCertificateVerifier clientCertificateVerifier = (AsyncCertificateVerifier) AsyncCertificateVerifier
+		AsyncCertificateVerifier clientCertificateVerifier = AsyncCertificateVerifier
 				.builder().setTrustAllCertificates().build();
 		clientsCertificateVerifiers.add(clientCertificateVerifier);
 
@@ -1972,7 +1972,7 @@ public class DTLSConnectorHandshakeTest {
 	public void testX509HandshakeSignatureAlgorithmsExtensionSha256Ecdsa() throws Exception {
 		startServer();
 
-		AsyncCertificateVerifier clientCertificateVerifier = (AsyncCertificateVerifier) AsyncCertificateVerifier
+		AsyncCertificateVerifier clientCertificateVerifier = AsyncCertificateVerifier
 				.builder().setTrustAllCertificates().build();
 		clientsCertificateVerifiers.add(clientCertificateVerifier);
 
@@ -1995,7 +1995,7 @@ public class DTLSConnectorHandshakeTest {
 						SignatureAndHashAlgorithm.SHA256_WITH_ECDSA);
 		startServer();
 
-		AsyncCertificateVerifier clientCertificateVerifier = (AsyncCertificateVerifier) AsyncCertificateVerifier
+		AsyncCertificateVerifier clientCertificateVerifier = AsyncCertificateVerifier
 				.builder().setTrustAllCertificates().build();
 		clientsCertificateVerifiers.add(clientCertificateVerifier);
 
@@ -2020,7 +2020,7 @@ public class DTLSConnectorHandshakeTest {
 					SignatureAndHashAlgorithm.SHA256_WITH_ECDSA);
 		startServer();
 
-		AsyncCertificateVerifier clientCertificateVerifier = (AsyncCertificateVerifier) AsyncCertificateVerifier
+		AsyncCertificateVerifier clientCertificateVerifier = AsyncCertificateVerifier
 				.builder().setTrustAllCertificates().build();
 		clientsCertificateVerifiers.add(clientCertificateVerifier);
 
@@ -2054,7 +2054,7 @@ public class DTLSConnectorHandshakeTest {
 		clientAlertCatcher.resetEvent();
 		client.destroy();
 
-		clientCertificateVerifier = (AsyncCertificateVerifier) AsyncCertificateVerifier.builder()
+		clientCertificateVerifier = AsyncCertificateVerifier.builder()
 				.setTrustAllCertificates().build();
 		clientsCertificateVerifiers.add(clientCertificateVerifier);
 
@@ -2079,7 +2079,7 @@ public class DTLSConnectorHandshakeTest {
 				SignatureAndHashAlgorithm.SHA256_WITH_ECDSA);
 		startServer();
 
-		AsyncCertificateVerifier clientCertificateVerifier = (AsyncCertificateVerifier) AsyncCertificateVerifier
+		AsyncCertificateVerifier clientCertificateVerifier = AsyncCertificateVerifier
 				.builder().setTrustAllCertificates().build();
 		clientsCertificateVerifiers.add(clientCertificateVerifier);
 
@@ -2115,7 +2115,7 @@ public class DTLSConnectorHandshakeTest {
 		logging.setLoggingLevel("ERROR", SingleCertificateProvider.class);
 		startServer();
 
-		AsyncCertificateVerifier clientCertificateVerifier = (AsyncCertificateVerifier) AsyncCertificateVerifier
+		AsyncCertificateVerifier clientCertificateVerifier = AsyncCertificateVerifier
 				.builder().setTrustAllCertificates().build();
 		clientsCertificateVerifiers.add(clientCertificateVerifier);
 
@@ -2147,7 +2147,7 @@ public class DTLSConnectorHandshakeTest {
 	public void testX509HandshakeFailingExpiredClientCertificate() throws Exception {
 		startServer();
 
-		AsyncCertificateVerifier clientCertificateVerifier = (AsyncCertificateVerifier) AsyncCertificateVerifier
+		AsyncCertificateVerifier clientCertificateVerifier = AsyncCertificateVerifier
 				.builder().setTrustAllCertificates().build();
 		clientsCertificateVerifiers.add(clientCertificateVerifier);
 
@@ -2180,7 +2180,7 @@ public class DTLSConnectorHandshakeTest {
 	public void testX509HandshakeFailingMissingClientCertificate() throws Exception {
 		startServer();
 
-		AsyncCertificateVerifier clientCertificateVerifier = (AsyncCertificateVerifier) AsyncCertificateVerifier
+		AsyncCertificateVerifier clientCertificateVerifier = AsyncCertificateVerifier
 				.builder().setTrustAllCertificates().build();
 		clientsCertificateVerifiers.add(clientCertificateVerifier);
 
@@ -2212,7 +2212,7 @@ public class DTLSConnectorHandshakeTest {
 		serverBuilder.set(DtlsConfig.DTLS_CLIENT_AUTHENTICATION_MODE, CertificateAuthenticationMode.NONE);
 		startServer();
 
-		AsyncCertificateVerifier clientCertificateVerifier = (AsyncCertificateVerifier) AsyncCertificateVerifier
+		AsyncCertificateVerifier clientCertificateVerifier = AsyncCertificateVerifier
 				.builder().setTrustAllCertificates().build();
 		clientsCertificateVerifiers.add(clientCertificateVerifier);
 
@@ -2246,7 +2246,7 @@ public class DTLSConnectorHandshakeTest {
 		serverBuilder.set(DtlsConfig.DTLS_CLIENT_AUTHENTICATION_MODE, CertificateAuthenticationMode.NONE);
 		startServer();
 
-		AsyncCertificateVerifier clientCertificateVerifier = (AsyncCertificateVerifier) AsyncCertificateVerifier
+		AsyncCertificateVerifier clientCertificateVerifier = AsyncCertificateVerifier
 				.builder().setTrustAllCertificates().build();
 		clientsCertificateVerifiers.add(clientCertificateVerifier);
 
@@ -2317,7 +2317,7 @@ public class DTLSConnectorHandshakeTest {
 		serverBuilder.set(DtlsConfig.DTLS_CLIENT_AUTHENTICATION_MODE, CertificateAuthenticationMode.WANTED);
 		startServer();
 
-		AsyncCertificateVerifier clientCertificateVerifier = (AsyncCertificateVerifier) AsyncCertificateVerifier
+		AsyncCertificateVerifier clientCertificateVerifier = AsyncCertificateVerifier
 				.builder().setTrustAllRPKs().build();
 		clientsCertificateVerifiers.add(clientCertificateVerifier);
 
@@ -2344,7 +2344,7 @@ public class DTLSConnectorHandshakeTest {
 		serverBuilder.set(DtlsConfig.DTLS_CLIENT_AUTHENTICATION_MODE, CertificateAuthenticationMode.WANTED);
 		startServer();
 
-		AsyncCertificateVerifier clientCertificateVerifier = (AsyncCertificateVerifier) AsyncCertificateVerifier
+		AsyncCertificateVerifier clientCertificateVerifier = AsyncCertificateVerifier
 				.builder().setTrustAllRPKs().build();
 		clientsCertificateVerifiers.add(clientCertificateVerifier);
 

--- a/scandium-core/src/test/java/org/eclipse/californium/scandium/DTLSConnectorResumeTest.java
+++ b/scandium-core/src/test/java/org/eclipse/californium/scandium/DTLSConnectorResumeTest.java
@@ -435,7 +435,7 @@ public class DTLSConnectorResumeTest {
 		pskStore.setKey(SCOPED_CLIENT_IDENTITY, SCOPED_CLIENT_IDENTITY_SECRET.getBytes(), SERVERNAME);
 		pskStore.setKey(SCOPED_CLIENT_IDENTITY, SCOPED_CLIENT_IDENTITY_SECRET.getBytes(), SERVERNAME_ALT);
 		serverPskStore = new AsyncPskStore(pskStore);
-		serverCertificateVerifier = (AsyncCertificateVerifier) AsyncCertificateVerifier.builder()
+		serverCertificateVerifier = AsyncCertificateVerifier.builder()
 				.setTrustedCertificates(DtlsTestTools.getTrustedCertificates()).setTrustAllRPKs().build();
 		serverResumptionVerifier = new AsyncResumptionVerifier();
 
@@ -466,7 +466,7 @@ public class DTLSConnectorResumeTest {
 		clientInMemoryPskStore.addKnownPeer(serverHelper.serverEndpoint, SERVERNAME_ALT, SCOPED_CLIENT_IDENTITY,
 				SCOPED_CLIENT_IDENTITY_SECRET.getBytes());
 		clientPskStore = new AsyncPskStore(clientInMemoryPskStore);
-		clientCertificateVerifier = (AsyncCertificateVerifier) AsyncCertificateVerifier.builder()
+		clientCertificateVerifier = AsyncCertificateVerifier.builder()
 				.setTrustedCertificates(DtlsTestTools.getTrustedCertificates()).setTrustAllRPKs().build();
 		clientCertificateProvider = new AsyncCertificateProvider(clientPrivateKey, clientCertificateChain,
 				CertificateType.RAW_PUBLIC_KEY, CertificateType.X_509);

--- a/scandium-core/src/test/java/org/eclipse/californium/scandium/DTLSConnectorResumeTest.java
+++ b/scandium-core/src/test/java/org/eclipse/californium/scandium/DTLSConnectorResumeTest.java
@@ -821,7 +821,7 @@ public class DTLSConnectorResumeTest {
 		assertThat(connection.getEstablishedSession().getSessionIdentifier(), is(sessionId));
 		assertClientIdentity(clientPrincipalType);
 
-		peer = serverHelper.getEstablishedServerDtlsSession(client.getAddress()).getPeerIdentity();
+		peer = serverHelper.getServersClientIdentity(client.getAddress());
 		assertThat(peer, is(instanceOf(ExtensiblePrincipal.class)));
 		principal = (ExtensiblePrincipal<?>) peer;
 		assertThat(principal.getExtendedInfo().get(KEY_DEVICE_ID, String.class), is(DEVICE_ID));

--- a/scandium-core/src/test/java/org/eclipse/californium/scandium/DTLSConnectorStartStopTest.java
+++ b/scandium-core/src/test/java/org/eclipse/californium/scandium/DTLSConnectorStartStopTest.java
@@ -141,7 +141,7 @@ public class DTLSConnectorStartStopTest {
 		clientChannel = new LatchDecrementingRawDataChannel();
 		client.setRawDataReceiver(clientChannel);
 		if (restoreClientConnection != null) {
-			client.restoreConnection(restoreClientConnection);
+			clientConnectionStore.restore(restoreClientConnection);
 			restoreClientConnection = null;
 		}
 	}

--- a/scandium-core/src/test/java/org/eclipse/californium/scandium/DTLSEndpointContextTest.java
+++ b/scandium-core/src/test/java/org/eclipse/californium/scandium/DTLSEndpointContextTest.java
@@ -287,7 +287,7 @@ public class DTLSEndpointContextTest {
 		assertNotNull(establishedClientSession);
 	}
 
-	private static class TestEndpointContextMatcher implements EndpointContextMatcher {
+	public static class TestEndpointContextMatcher implements EndpointContextMatcher {
 
 		private final int count;
 		private final CountDownLatch latchSendMatcher;

--- a/scandium-core/src/test/java/org/eclipse/californium/scandium/auth/PrincipalSerializerTest.java
+++ b/scandium-core/src/test/java/org/eclipse/californium/scandium/auth/PrincipalSerializerTest.java
@@ -27,6 +27,7 @@ import java.security.NoSuchAlgorithmException;
 import java.security.PublicKey;
 import java.security.cert.Certificate;
 
+import org.eclipse.californium.elements.auth.ApplicationPrincipal;
 import org.eclipse.californium.elements.auth.PreSharedKeyIdentity;
 import org.eclipse.californium.elements.auth.RawPublicKeyIdentity;
 import org.eclipse.californium.elements.auth.X509CertPath;
@@ -37,7 +38,6 @@ import org.eclipse.californium.scandium.dtls.DtlsTestTools;
 import org.junit.BeforeClass;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
-
 
 /**
  * Verifies behavior of {@link PrincipalSerializer}.
@@ -53,9 +53,8 @@ public class PrincipalSerializerTest {
 	 * Creates a public key to be used in test cases.
 	 * 
 	 * @throws GeneralSecurityException if the demo server certificate chain
-	 *              cannot be read.
-	 * @throws IOException if the demo server certificate chain
-	 *              cannot be read.
+	 *             cannot be read.
+	 * @throws IOException if the demo server certificate chain cannot be read.
 	 */
 	@BeforeClass
 	public static void init() throws IOException, GeneralSecurityException {
@@ -70,9 +69,9 @@ public class PrincipalSerializerTest {
 	}
 
 	/**
-	 * Verifies that a pre-shared key identity that has been serialized using the
-	 * serialize method can be re-instantiated properly using the deserialize
-	 * method.
+	 * Verifies that a pre-shared key identity that has been serialized using
+	 * the serialize method can be re-instantiated properly using the
+	 * deserialize method.
 	 */
 	@Test
 	public void testSerializedPSKIdentityCanBeDeserialized() {
@@ -81,9 +80,9 @@ public class PrincipalSerializerTest {
 	}
 
 	/**
-	 * Verifies that a pre-shared key identity without a virtual host that has been
-	 * serialized using the serialize method can be re-instantiated properly using
-	 * the deserialize method.
+	 * Verifies that a pre-shared key identity without a virtual host that has
+	 * been serialized using the serialize method can be re-instantiated
+	 * properly using the deserialize method.
 	 */
 	@Test
 	public void testSerializedPSKIdentityWithoutHostCanBeDeserialized() {
@@ -100,7 +99,8 @@ public class PrincipalSerializerTest {
 
 			// THEN the resulting byte array can be used to re-instantiate
 			// the identity
-			PreSharedKeyIdentity identity = (PreSharedKeyIdentity) PrincipalSerializer.deserialize(new DatagramReader(writer.toByteArray()));
+			PreSharedKeyIdentity identity = (PreSharedKeyIdentity) PrincipalSerializer
+					.deserialize(new DatagramReader(writer.toByteArray()));
 			assertThat(identity, is(pskIdentity));
 		} catch (GeneralSecurityException e) {
 			// should not happen
@@ -109,9 +109,8 @@ public class PrincipalSerializerTest {
 	}
 
 	/**
-	 * Verifies that a public key that has been serialized using the
-	 * serialize method can be re-instantiated properly using the deserialize
-	 * method.
+	 * Verifies that a public key that has been serialized using the serialize
+	 * method can be re-instantiated properly using the deserialize method.
 	 * 
 	 * @throws GeneralSecurityException if the key cannot be deserialized.
 	 */
@@ -126,7 +125,8 @@ public class PrincipalSerializerTest {
 
 		// THEN the resulting byte array can be used to re-instantiate
 		// the public key
-		RawPublicKeyIdentity identity = (RawPublicKeyIdentity) PrincipalSerializer.deserialize(new DatagramReader(writer.toByteArray()));
+		RawPublicKeyIdentity identity = (RawPublicKeyIdentity) PrincipalSerializer
+				.deserialize(new DatagramReader(writer.toByteArray()));
 		assertThat(identity.getKey(), is(publicKey));
 		assertThat(identity.getKey().getAlgorithm(), is(publicKey.getAlgorithm()));
 	}
@@ -153,6 +153,58 @@ public class PrincipalSerializerTest {
 		assertThat(identity.getName(), is(x509Identity.getName()));
 		assertThat(identity.getTarget(), is(x509Identity.getTarget()));
 		assertThat(identity.getPath(), is(x509Identity.getPath()));
+	}
+
+	/**
+	 * Verifies that an anonymous application authorization has been serialized
+	 * using the serialize method can be re-instantiated properly using the
+	 * deserialize method.
+	 * 
+	 * @throws GeneralSecurityException if the key cannot be deserialized.
+	 */
+	@Test
+	public void testSerializedAnonymousApplicationPrincipal() throws GeneralSecurityException {
+
+		// WHEN serializing the application authorization to a byte array
+		DatagramWriter writer = new DatagramWriter();
+		PrincipalSerializer.serialize(ApplicationPrincipal.ANONYMOUS, writer);
+
+		// THEN the resulting byte array can be used to re-instantiate
+		ApplicationPrincipal identity = (ApplicationPrincipal) PrincipalSerializer
+				.deserialize(new DatagramReader(writer.toByteArray()));
+		assertThat(identity, is(ApplicationPrincipal.ANONYMOUS));
+	}
+
+	/**
+	 * Verifies that an application authorization has been serialized using the
+	 * serialize method can be re-instantiated properly using the deserialize
+	 * method.
+	 * 
+	 * @throws GeneralSecurityException if the key cannot be deserialized.
+	 */
+	@Test
+	public void testSerializedApplicationPrincipal() throws GeneralSecurityException {
+
+		// WHEN serializing the application authorization to a byte array
+		DatagramWriter writer = new DatagramWriter();
+		ApplicationPrincipal principal = new ApplicationPrincipal("me", false);
+		PrincipalSerializer.serialize(principal, writer);
+
+		// THEN the resulting byte array can be used to re-instantiate
+		ApplicationPrincipal identity = (ApplicationPrincipal) PrincipalSerializer
+				.deserialize(new DatagramReader(writer.toByteArray()));
+		assertThat(identity, is(principal));
+
+		// WHEN serializing the application authorization to a byte array
+		writer = new DatagramWriter();
+		principal = new ApplicationPrincipal("you", true);
+		PrincipalSerializer.serialize(principal, writer);
+
+		// THEN the resulting byte array can be used to re-instantiate
+		identity = (ApplicationPrincipal) PrincipalSerializer
+				.deserialize(new DatagramReader(writer.toByteArray()));
+		assertThat(identity, is(principal));
+		
 	}
 
 }

--- a/scandium-core/src/test/java/org/eclipse/californium/scandium/dtls/DebugInMemoryConnectionStore.java
+++ b/scandium-core/src/test/java/org/eclipse/californium/scandium/dtls/DebugInMemoryConnectionStore.java
@@ -96,8 +96,8 @@ public final class DebugInMemoryConnectionStore extends InMemoryConnectionStore
 	 */
 	private void dump(Connection connection) {
 		if (connection.hasEstablishedDtlsContext()) {
-			LOG.info("  {}connection: {} - {} : {}", tag, connection.getConnectionId(), connection.getPeerAddress(),
-					connection.getEstablishedSession().getSessionIdentifier());
+			LOG.info("  {}connection: {} - {} : {} {}", tag, connection.getConnectionId(), connection.getPeerAddress(),
+					connection.getEstablishedPeerIdentity(), connection.getEstablishedSession().getSessionIdentifier());
 		} else {
 			LOG.info("  {}connection: {} - {}", tag, connection.getConnectionId(), connection.getPeerAddress());
 		}


### PR DESCRIPTION
For some application and proxies, it may be advantageous to use a common HTTP authentication pattern, where the client stays on TLS level anonymous and applies it's authentication then on application level, e.g. username/password or tokens.
This PR improves the support for that by adding an `ApplicationPrincipal`, an `ApplicationAuthorizer` and a new configuration "DTLS.APPLICATION_AUTHORIZATION_TIMEOUT", which enables to define a timeout for an application authorization.