### PR TITLE
Remove probing handshake.

### DIFF
--- a/element-connector/src/main/java/org/eclipse/californium/elements/DtlsEndpointContext.java
+++ b/element-connector/src/main/java/org/eclipse/californium/elements/DtlsEndpointContext.java
@@ -88,12 +88,11 @@ public class DtlsEndpointContext extends MapBasedEndpointContext {
 			KEY_PREFIX_NONE_CRITICAL + "DTLS_VIA_ROUTER", String.class, ATTRIBUTE_DEFINITIONS);
 	/**
 	 * The name of the attribute that contains a handshake mode. Values see
-	 * {@link #HANDSHAKE_MODE_FORCE_FULL}, {@link #HANDSHAKE_MODE_FORCE},
-	 * {@link #HANDSHAKE_MODE_PROBE}, and {@link #HANDSHAKE_MODE_NONE}. Only
-	 * considered, if endpoint is not configured as "server only". If not
-	 * provided, a handshake will be started, if required and the connector is
-	 * not configured to act as server only. None critical attribute, not
-	 * considered for matching.
+	 * {@link #HANDSHAKE_MODE_FORCE_FULL}, {@link #HANDSHAKE_MODE_FORCE}, and
+	 * {@link #HANDSHAKE_MODE_NONE}. Only considered, if endpoint is not
+	 * configured as "server only". If not provided, a handshake will be
+	 * started, if required and the connector is not configured to act as server
+	 * only. None critical attribute, not considered for matching.
 	 */
 	public static final Definition<String> KEY_HANDSHAKE_MODE = new Definition<>(
 			KEY_PREFIX_NONE_CRITICAL + "DTLS_HANDSHAKE_MODE", String.class, ATTRIBUTE_DEFINITIONS);
@@ -161,11 +160,6 @@ public class DtlsEndpointContext extends MapBasedEndpointContext {
 	 */
 	public static final String HANDSHAKE_MODE_FORCE = "force";
 	/**
-	 * Force handshake probe before send this message. Doesn't start a
-	 * handshake, if the connector is configured to act as server only.
-	 */
-	public static final String HANDSHAKE_MODE_PROBE = "probe";
-	/**
 	 * Start a handshake, if no session is available.
 	 */
 	public static final String HANDSHAKE_MODE_AUTO = "auto";
@@ -187,13 +181,6 @@ public class DtlsEndpointContext extends MapBasedEndpointContext {
 	 */
 	public static final Attributes ATTRIBUTE_HANDSHAKE_MODE_AUTO = new Attributes()
 			.add(KEY_HANDSHAKE_MODE, HANDSHAKE_MODE_AUTO).lock();
-	/**
-	 * Attribute to set HANDSHAKE_MODE to {@link #HANDSHAKE_MODE_PROBE}.
-	 * 
-	 * @since 3.0
-	 */
-	public static final Attributes ATTRIBUTE_HANDSHAKE_MODE_PROBE = new Attributes()
-			.add(KEY_HANDSHAKE_MODE, HANDSHAKE_MODE_PROBE).lock();
 	/**
 	 * Attribute to set HANDSHAKE_MODE to {@link #HANDSHAKE_MODE_FORCE}.
 	 * 

--- a/scandium-core/src/main/java/org/eclipse/californium/scandium/dtls/ClientHandshaker.java
+++ b/scandium-core/src/main/java/org/eclipse/californium/scandium/dtls/ClientHandshaker.java
@@ -164,11 +164,6 @@ public class ClientHandshaker extends Handshaker {
 	private ProtocolVersion maxProtocolVersion = ProtocolVersion.VERSION_DTLS_1_2;
 
 	/**
-	 * Indicates probing for this handshake.
-	 */
-	private boolean probe;
-
-	/**
 	 * Indicates received server hello done.
 	 * 
 	 * @since 3.0
@@ -276,13 +271,11 @@ public class ClientHandshaker extends Handshaker {
 	 * @param timer scheduled executor for flight retransmission (since 2.4).
 	 * @param connection the connection related with the session.
 	 * @param config the DTLS configuration.
-	 * @param probe {@code true} enable probing for this handshake,
-	 *            {@code false}, not probing handshake.
 	 * @throws NullPointerException if any of the provided parameter is
 	 *             {@code null}, except the hostname.
 	 */
 	public ClientHandshaker(String hostname, RecordLayer recordLayer, ScheduledExecutorService timer,
-			Connection connection, DtlsConnectorConfig config, boolean probe) {
+			Connection connection, DtlsConnectorConfig config) {
 		super(0, 0, recordLayer, timer, connection, config);
 
 		List<CipherSuite> cipherSuites = config.getSupportedCipherSuites();
@@ -304,7 +297,6 @@ public class ClientHandshaker extends Handshaker {
 		this.supportedClientCertificateTypes = config.getIdentityCertificateTypes();
 		this.supportedSignatureAlgorithms = config.getSupportedSignatureAlgorithms();
 		this.verifyServerCertificatesSubject = config.get(DtlsConfig.DTLS_VERIFY_SERVER_CERTIFICATES_SUBJECT);
-		this.probe = probe;
 		getSession().setHostName(hostname);
 	}
 
@@ -1003,25 +995,5 @@ public class ClientHandshaker extends Handshaker {
 			}
 		}
 		return pskIdentity;
-	}
-
-	@Override
-	public boolean isProbing() {
-		return probe;
-	}
-
-	@Override
-	public void resetProbing() {
-		probe = false;
-	}
-
-	/**
-	 * {@inheritDoc}
-	 * 
-	 * Connections of probing handshakes are not intended to be removed.
-	 */
-	@Override
-	public boolean isRemovingConnection() {
-		return !probe && super.isRemovingConnection();
 	}
 }

--- a/scandium-core/src/main/java/org/eclipse/californium/scandium/dtls/Handshaker.java
+++ b/scandium-core/src/main/java/org/eclipse/californium/scandium/dtls/Handshaker.java
@@ -2019,7 +2019,7 @@ public abstract class Handshaker implements Destroyable {
 		if (!flight.isResponseCompleted()) {
 			Handshaker handshaker = connection.getOngoingHandshake();
 			if (null != handshaker) {
-				if (!handshaker.isProbing() && connection.hasEstablishedDtlsContext()) {
+				if (connection.hasEstablishedDtlsContext()) {
 					return;
 				}
 				Exception cause = null;
@@ -2342,35 +2342,6 @@ public abstract class Handshaker implements Destroyable {
 	 */
 	public boolean hasContextEstablished() {
 		return contextEstablished;
-	}
-
-	/**
-	 * Test, if handshake was started in probing mode.
-	 * 
-	 * Usually a resuming client handshake removes the DTLS context from the
-	 * connection store with the start. Probing removes DTLS context only with
-	 * the first data received back. If the handshake expires before some data
-	 * is received back, the original DTLS context is used again.
-	 * 
-	 * @return {@code true}, if handshake is in probing mode, {@code false},
-	 *         otherwise.
-	 * @see ResumingClientHandshaker
-	 * @see ClientHandshaker
-	 * @since 2.1
-	 */
-	public boolean isProbing() {
-		// intended to be overridden by the ResumingClientHandshaker
-		return false;
-	}
-
-	/**
-	 * Reset probing mode, when data is received during.
-	 * 
-	 * @see ResumingClientHandshaker
-	 * @since 2.1
-	 */
-	public void resetProbing() {
-		// intended to be overriden by the ResumingClientHandshaker
 	}
 
 	/**

--- a/scandium-core/src/main/java/org/eclipse/californium/scandium/dtls/ResumingClientHandshaker.java
+++ b/scandium-core/src/main/java/org/eclipse/californium/scandium/dtls/ResumingClientHandshaker.java
@@ -131,16 +131,14 @@ public class ResumingClientHandshaker extends ClientHandshaker {
 	 *            the connection related with the session.
 	 * @param config
 	 *            the DTLS configuration parameters to use for the handshake.
-	 * @param probe {@code true} enable probing for this resumption handshake,
-	 *            {@code false}, not probing handshake.
 	 * @throws IllegalArgumentException
 	 *            if the given session does not contain an identifier.
 	 * @throws NullPointerException if any of the provided parameter is
 	 *             {@code null}
 	 */
 	public ResumingClientHandshaker(DTLSSession session, RecordLayer recordLayer, ScheduledExecutorService timer, Connection connection,
-			DtlsConnectorConfig config, boolean probe) {
-		super(null, recordLayer, timer, connection, config, probe);
+			DtlsConnectorConfig config) {
+		super(null, recordLayer, timer, connection, config);
 		SessionId sessionId = session.getSessionIdentifier();
 		if (sessionId.isEmpty()) {
 			throw new IllegalArgumentException("Session must contain the ID of the session to resume");

--- a/scandium-core/src/test/java/org/eclipse/californium/scandium/dtls/AdversaryClientHandshaker.java
+++ b/scandium-core/src/test/java/org/eclipse/californium/scandium/dtls/AdversaryClientHandshaker.java
@@ -50,7 +50,7 @@ public class AdversaryClientHandshaker extends ClientHandshaker {
 	 */
 	public AdversaryClientHandshaker(DTLSSession session, RecordLayer recordLayer, ScheduledExecutorService timer, Connection connection,
 			DtlsConnectorConfig config) {
-		super(null, recordLayer, timer, connection, config, false);
+		super(null, recordLayer, timer, connection, config);
 		getSession().set(session);
 	}
 

--- a/scandium-core/src/test/java/org/eclipse/californium/scandium/dtls/ClientHandshakerTest.java
+++ b/scandium-core/src/test/java/org/eclipse/californium/scandium/dtls/ClientHandshakerTest.java
@@ -301,8 +301,7 @@ public class ClientHandshakerTest {
 				recordLayer,
 				timer,
 				connection,
-				config,
-				false);
+				config);
 		recordLayer.setHandshaker(handshaker);
 	}
 
@@ -322,8 +321,7 @@ public class ClientHandshakerTest {
 				recordLayer,
 				timer,
 				connection,
-				config,
-				false);
+				config);
 		recordLayer.setHandshaker(handshaker);
 	}
 


### PR DESCRIPTION
Using DTLS 1.2 CID a probing handshake on a client is very rarely used and so the benefit got very small. Therefore this feature is removed.