### PR TITLE
Fix reliability parameter for CON notifies.

### DIFF
--- a/californium-core/src/main/java/org/eclipse/californium/core/network/Exchange.java
+++ b/californium-core/src/main/java/org/eclipse/californium/core/network/Exchange.java
@@ -1331,6 +1331,19 @@ public class Exchange {
 	}
 
 	/**
+	 * Reset transmission of observe relation.
+	 * 
+	 * @param relation observe relation
+	 * @since 3.14
+	 */
+	public void resetRelationTransmission(ObserveRelation relation) {
+		assertOwner();
+		if (this.relation == relation) {
+			this.failedTransmissionCount = 0;
+		}
+	}
+
+	/**
 	 * Remove past notifications from message exchange store.
 	 * 
 	 * To be able to react on RST for notifications, the NON notifications are

--- a/californium-core/src/main/java/org/eclipse/californium/core/observe/ObserveRelation.java
+++ b/californium-core/src/main/java/org/eclipse/californium/core/observe/ObserveRelation.java
@@ -462,6 +462,10 @@ public class ObserveRelation {
 	public Response getNextNotification(Response response, boolean acknowledged) {
 		Response next = null;
 		if (recentControlNotification == response) {
+			if (acknowledged) {
+				// reset transmission
+				exchange.resetRelationTransmission(this);
+			}
 			next = nextControlNotification;
 			if (next != null) {
 				// next may be null

--- a/californium-core/src/test/java/org/eclipse/californium/core/test/lockstep/ObserveServerSideTest.java
+++ b/californium-core/src/test/java/org/eclipse/californium/core/test/lockstep/ObserveServerSideTest.java
@@ -192,6 +192,8 @@ public class ObserveServerSideTest {
 		testObsResource.setObserveType(CON);
 		testObsResource.change("Third notification");
 		client.expectResponse().type(CON).code(CONTENT).token(tok).storeMID("MID").checkObs("B", "C").payload(respPayload).go();
+		serverInterceptor.log(" // lost");
+		client.expectResponse().type(CON).code(CONTENT).token(tok).sameMID("MID").loadObserve("C").payload(respPayload).go();
 		client.sendEmpty(ACK).loadMID("MID").go();
 
 		// Forth notification


### PR DESCRIPTION
Add lost CON notify to unit test checking reset of the reliability parameter.

Fixes issue #2333