### PR TITLE
Fix bundle dependencies on SLF4J (Californium 4.0.x)

### DIFF
--- a/element-connector/pom.xml
+++ b/element-connector/pom.xml
@@ -63,9 +63,11 @@
 							org.eclipse.californium.elements*
 						</Export-Package>
 						<Import-Package>
+							org.slf4j.bridge;resolution:=optional,
 							*
 						</Import-Package>
 						<Bundle-SymbolicName>${project.groupId}.${project.artifactId}</Bundle-SymbolicName>
+						<_noclassforname>true</_noclassforname>
 					</instructions>
 				</configuration>
 			</plugin>


### PR DESCRIPTION
The same as PR #2337 but for Californium 4.0.x and newer (e.g. main)
It contrast to the previous PR this one is missing the obsolete compatibility fix for SLF4J 2.0 as Californium 4.0.0 already uses SLF4J 2.0 natively.

For completeness a copy of the issue description from PR #2337:
> The OSGi bundles org.eclipse.californium:element-connector 3.14.0 and also 4.0.0-M3 have a mandatory dependency on org.slf4j.bridge although this should be an optional dependency.
> 
> The origin of the dependency is the call to Class.forName("org.slf4j.bridge.SLF4JBridgeHandler") in JceProviderUtil.setupLoggingBridge(). While analyzing this file, the BND tool (internally used by the maven-bundle-plugin) finds the Class.forName call and creates an Import for org.slf4j.bridge in the resulting Bundle Manifest.
> 
> According to the JavaDoc of JceProviderUtil this dependency should not be required:
> 
> The bridge is only activated, if "CALIFORNIUM_JCE_PROVIDER" is set to "BC" ...
> 
> As a consequence when using element-connector with OSGi the org.slf4j.bridge bundle must also be used. This is a problem in our project as we already use the JUL to Log4J2 bundle (log4j-jul) as a bridge for JUL. Using two bridges in parallel for JUL does not seem to be a good idea.
> 
> This PR contains a fix to make org.slf4j.bridge an optional dependency by adding a new config entry to the maven-bundle-plugin config.
> In addition the PR adds the [-noclassforname](https://bnd.bndtools.org/instructions/noclassforname.html) instruction to the maven-bundle-plugin config, so that BND will not search for uses of Class.forName() anymore. Although the -noclassforname (added in BND 4.3.0) is not necessary to fix this issue, it might avoid problems with false mandatory dependencies in the future. With this instruction there will be no Import in the Manifest for the classes referenced by Class.forName() at all - which is still better than having a required one.

