### PR TITLE
Cleanup auxiliary destroy function.

### DIFF
--- a/MIGRATION_HINTS_4.md
+++ b/MIGRATION_HINTS_4.md
@@ -136,6 +136,8 @@ Remove `restoreConnection` from `DTLSConnector`.
 
 Replace `DtlsBlockConnectionState.getMac` by `DtlsBlockConnectionState.initMac`. Adapt `CbcBlockCipher.getBlockCipherMac()` to use a already initialized `Mac` and remove the `macKey` from the parameter list.
 
+Remove obsolete `destroy(PrivateKey key)`, `destroy(SecretKey key)`, `isDestroyed(PrivateKey key)`, and `isDestroyed(SecretKey key)` from `SecretUtil`. Java 8 supports the `Destroyable` for both `PrivateKey` and `SecretKey` obsoletes that workaround.
+
 ### Californium-Core:
 
 The functions of the obsolete and removed `ExtendedCoapStack` are moved into

--- a/element-connector/src/main/java/org/eclipse/californium/elements/util/SslContextUtil.java
+++ b/element-connector/src/main/java/org/eclipse/californium/elements/util/SslContextUtil.java
@@ -1365,13 +1365,6 @@ public class SslContextUtil {
 	public static class Credentials implements Destroyable {
 
 		/**
-		 * Indicates, that this instance has been {@link #destroy()}ed.
-		 * 
-		 * @since 3.12
-		 */
-		private volatile boolean destroyed;
-
-		/**
 		 * Private key.
 		 */
 		private final PrivateKey privateKey;
@@ -1552,10 +1545,9 @@ public class SslContextUtil {
 		 */
 		@Override
 		public void destroy() throws DestroyFailedException {
-			if (privateKey instanceof Destroyable) {
-				((Destroyable) privateKey).destroy();
+			if (privateKey != null) {
+				privateKey.destroy();
 			}
-			destroyed = true;
 		}
 
 		/**
@@ -1565,7 +1557,7 @@ public class SslContextUtil {
 		 */
 		@Override
 		public boolean isDestroyed() {
-			return destroyed || (privateKey == null && trusts == null && publicKey == null);
+			return privateKey == null || privateKey.isDestroyed();
 		}
 	}
 

--- a/scandium-core/src/main/java/org/eclipse/californium/scandium/util/SecretUtil.java
+++ b/scandium-core/src/main/java/org/eclipse/californium/scandium/util/SecretUtil.java
@@ -16,7 +16,6 @@
 package org.eclipse.californium.scandium.util;
 
 import java.security.MessageDigest;
-import java.security.PrivateKey;
 import java.security.spec.KeySpec;
 import java.util.Arrays;
 
@@ -36,30 +35,7 @@ public class SecretUtil {
 	private static final Logger LOGGER = LoggerFactory.getLogger(SecretUtil.class);
 
 	/**
-	 * Destroy private key.
-	 * 
-	 * @param key private key to destroy. If {@code null}, nothing is destroyed.
-	 * @since 3.12
-	 */
-	public static void destroy(PrivateKey key) {
-		if (key instanceof Destroyable) {
-			destroy((Destroyable) key);
-		}
-	}
-
-	/**
-	 * Destroy secret key.
-	 * 
-	 * @param key secret key to destroy. If {@code null}, nothing is destroyed.
-	 */
-	public static void destroy(SecretKey key) {
-		if (key instanceof Destroyable) {
-			destroy((Destroyable) key);
-		}
-	}
-
-	/**
-	 * Destroy provided security destroyable.
+	 * Destroy provided security {@code Destroyable}.
 	 * 
 	 * @param destroyable object to destroy. Maybe {@code null}.
 	 */
@@ -74,43 +50,6 @@ public class SecretUtil {
 				LOGGER.warn("Destroy on {} failed!", destroyable.getClass(), e);
 			}
 		}
-	}
-
-	/**
-	 * Checks if a private key has already been destroyed.
-	 * 
-	 * @param key private key to check (may be {@code null}).
-	 * @return {@code true} if the key either is {@code null} or has been
-	 *         destroyed.
-	 * @since 3.12
-	 */
-	public static boolean isDestroyed(PrivateKey key) {
-		if (key != null) {
-			if (key instanceof Destroyable) {
-				return ((Destroyable) key).isDestroyed();
-			} else {
-				return false;
-			}
-		}
-		return true;
-	}
-
-	/**
-	 * Checks if a secret key has already been destroyed.
-	 * 
-	 * @param key secret key to check (may be {@code null}).
-	 * @return {@code true} if the key either is {@code null} or has been
-	 *         destroyed.
-	 */
-	public static boolean isDestroyed(SecretKey key) {
-		if (key != null) {
-			if (key instanceof Destroyable) {
-				return ((Destroyable) key).isDestroyed();
-			} else {
-				return false;
-			}
-		}
-		return true;
 	}
 
 	/**


### PR DESCRIPTION
Java 8 supports Destroyable for SecretKey and PrivateKey obsoletes the workaround helper function.